### PR TITLE
New thenClick step

### DIFF
--- a/casper.js
+++ b/casper.js
@@ -225,6 +225,21 @@
         },
 
         /**
+         * Adds a new navigation step for clicking on a provided link.
+         *
+         * @param  String   selector  A DOM CSS3 compatible selector
+         * @param  function then      Next step function to execute on page loaded (optional)
+         * @return Casper
+         * @see    Casper#open
+         */
+        thenClick: function(selector, fallbackToHref, then) {
+            this.then(function(self) {
+                self.click(selector, fallbackToHref);
+            });
+            return typeof then === "function" ? this.then(then) : this;
+        },
+
+        /**
          * Logs the HTML code of the current page.
          *
          * @return Casper


### PR DESCRIPTION
I've added a "thenClick" function to solve the following problem.

Let's imagine that I test a website page like this : 
- I open the website
- I click on a button with opens a div (content loaded with Ajax call)
- I want to click on a link in this div, which will open a new page

I didn't find a way to do it without the step I've added. My js script is now :

``` javascript
casper.start('http://mywebsite/', function(self) {
  self.click('a#popin');
  self.waitForSelector('div.popin-content', function(self) {
    self.test.assert(true, 'div.popin-content has appeared as expected');
    resumeTests(self);
  }, function (self) {
    self.test.assert(false, 'div.popin-content has appeared as expected');
  });
});
function resumeTests(self) {
  self.thenClick('a#in_popin', true, function(self) {
    self.test.assert(true, 'at last, I can continue my tests');
  });
}
```
