### PR TITLE
A new log level

### DIFF
--- a/casper.js
+++ b/casper.js
@@ -71,8 +71,9 @@
         this.delayedExecution = false;
         this.history = [];
         this.loadInProgress = false;
-        this.logLevels = ["debug", "info", "warning", "error"];
+        this.logLevels = ["verbose", "debug", "info", "warning", "error"];
         this.logStyles = {
+            verbose: 'INFO',
             debug:   'INFO',
             info:    'PARAMETER',
             warning: 'COMMENT',
@@ -1766,6 +1767,13 @@
             if (isType(casper.options.onResourceReceived, "function")) {
                 casper.options.onResourceReceived.call(casper, casper, resource);
             }
+            var message = 'received : '+resource.url+', '+resource.status+', '+resource.statusText+', '+resource.redirectURL+', '+resource.bodySize+', ';
+            var idx = null;
+            for (idx in resource.headers)
+            {
+                message += '['+resource.headers[idx].name+','+resource.headers[idx].value+'] ';
+            }
+            casper.log(message, "verbose");
             if (resource.url === casper.requestUrl && resource.stage === "start") {
                 casper.currentHTTPStatus = resource.status;
                 if (isType(casper.options.httpStatusHandlers, "object") && resource.status in casper.options.httpStatusHandlers) {


### PR DESCRIPTION
As i mentioned in issue 23; I was looking for a way to have more logs to see what was going on between phantomjs and the server.

So here it is. I've named it "verbose" because it tells a LOT of things ;)

For each request received, it shows something like :
[verbose] [phantom] received : http://xxxx, OK, null, 11700, [Date,Wed, 07 Dec 2011 09:48:12 GMT] [Server,Apache/2.2.21 (Debian)] [X-Powered-By,PHP/5.3.8-1+b1] [Expires,Thu, 19 Nov 1981 08:52:00 GMT] [Cache-Control,no-store, no-cache, must-revalidate, post-check=0, pre-check=0] [Pragma,no-cache] [Vary,Accept-Encoding] [Content-Encoding,gzip] [Keep-Alive,timeout=5, max=32] [Connection,Keep-Alive] [Content-Type,text/html; charset=utf-8]
