### PR TITLE
Use file name of test script as 'classname' in JUnit XML report

### DIFF
--- a/modules/tester.js
+++ b/modules/tester.js
@@ -47,7 +47,7 @@ var Tester = function(casper, options) {
     }
 
     this.currentTestFile = null;
-    this.exporter = require('xunit').create();
+    this.exporter = require('xunit').create(casper);
     this.running = false;
     this.suites = [];
     this.options = utils.mergeObjects({
@@ -86,13 +86,13 @@ var Tester = function(casper, options) {
             eventName = 'success';
             style = 'INFO';
             this.testResults.passed++;
-            this.exporter.addSuccess("unknown", message);
+            this.exporter.addSuccess(message);
         } else {
             eventName = 'fail';
             status = this.options.failText;
             style = 'RED_BAR';
             this.testResults.failed++;
-            this.exporter.addFailure("unknown", message, 'test failed', "assert");
+            this.exporter.addFailure(message, 'test failed', "assert");
         }
         this.emit(eventName, {
             message: message,
@@ -114,14 +114,14 @@ var Tester = function(casper, options) {
             eventName = "success";
             casper.echo(this.colorize(this.options.passText, 'INFO') + ' ' + this.formatMessage(message));
             this.testResults.passed++;
-            this.exporter.addSuccess("unknown", message);
+            this.exporter.addSuccess(message);
         } else {
             eventName = "fail";
             casper.echo(this.colorize(this.options.failText, 'RED_BAR') + ' ' + this.formatMessage(message, 'WARNING'));
             this.comment('   got:      ' + utils.serialize(testValue));
             this.comment('   expected: ' + utils.serialize(expected));
             this.testResults.failed++;
-            this.exporter.addFailure("unknown", message, f("test failed; expected: %s; got: %s", expected, testValue), "assertEquals");
+            this.exporter.addFailure(message, f("test failed; expected: %s; got: %s", expected, testValue), "assertEquals");
         }
         this.emit(eventName, {
             message: message,
@@ -175,14 +175,14 @@ var Tester = function(casper, options) {
             eventName = "success";
             casper.echo(this.colorize(this.options.passText, 'INFO') + ' ' + this.formatMessage(message));
             this.testResults.passed++;
-            this.exporter.addSuccess("unknown", message);
+            this.exporter.addSuccess(message);
         } else {
             eventName = "fail";
             casper.echo(this.colorize(this.options.failText, 'RED_BAR') + ' ' + this.formatMessage(message, 'WARNING'));
             this.comment('   subject: ' + subject);
             this.comment('   pattern: ' + pattern.toString());
             this.testResults.failed++;
-            this.exporter.addFailure("unknown", message, f("test failed; subject: %s; pattern: %s", subject, pattern.toString()), "assertMatch");
+            this.exporter.addFailure(message, f("test failed; subject: %s; pattern: %s", subject, pattern.toString()), "assertMatch");
         }
         this.emit(eventName, {
             message: message,

--- a/tests/suites/xunit.js
+++ b/tests/suites/xunit.js
@@ -1,9 +1,9 @@
 casper.test.comment('phantom.Casper.XUnitExporter');
 
-xunit = require('xunit').create();
-xunit.addSuccess('foo', 'bar');
-casper.test.assertMatch(xunit.getXML(), /<testcase classname="foo" name="bar"/, 'XUnitExporter.addSuccess() adds a successful testcase');
-xunit.addFailure('bar', 'baz', 'wrong', 'chucknorriz');
-casper.test.assertMatch(xunit.getXML(), /<testcase classname="bar" name="baz"><failure type="chucknorriz">wrong/, 'XUnitExporter.addFailure() adds a failed testcase');
+xunit = require('xunit').create(casper);
+xunit.addSuccess('bar');
+casper.test.assertMatch(xunit.getXML(), /<testcase classname="tests\/suites\/xunit" name="bar"/, 'XUnitExporter.addSuccess() adds a successful testcase');
+xunit.addFailure('baz', 'wrong', 'chucknorriz');
+casper.test.assertMatch(xunit.getXML(), /<testcase classname="tests\/suites\/xunit" name="baz"><failure type="chucknorriz">wrong/, 'XUnitExporter.addFailure() adds a failed testcase');
 
 casper.test.done();


### PR DESCRIPTION
Hi,

What do you think of using script file names as class names in JUnit xml report? I think it helps readability of the results for example in Jenkins report.

-Mikko-
