### PR TITLE
allow specification of raw query string

### DIFF
--- a/modules/clientutils.js
+++ b/modules/clientutils.js
@@ -303,6 +303,8 @@
                         }
                         dataString = dataList.join('&');
                         this.log("getBinary(): Using request data: '" + dataString + "'", "debug");
+                    } else if (typeof data === "string") {
+                        dataString = data;
                     }
                     xhr.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
                 }


### PR DESCRIPTION
this is useful in cases where there are hidden form fields you need to grab via something like

```
var form_data = this.evaluate(function() {
  return jQuery('form').serialize();
});
var base64contents = this.base64encode(form_url, 'POST', form_data);
```
