### PR TITLE
casperjs can't be killed and wastes memory

### DIFF
--- a/bin/casperjs
+++ b/bin/casperjs
@@ -48,11 +48,7 @@ CASPER_COMMAND.extend([os.path.join(CASPER_PATH, 'bin', 'bootstrap.js'), '--casp
 CASPER_COMMAND.extend(CASPER_ARGS)
 
 try:
-    status = subprocess.call(CASPER_COMMAND)
+    os.execvp(CASPER_COMMAND[0], CASPER_COMMAND)
 except OSError, err:
-    status = 1
     print('Fatal: %s; did you install phantomjs?' % err)
-except KeyboardInterrupt:
-    print('\nCasperJS interrupted, exiting.')
-    status = 0
-sys.exit(status)
+    sys.exit(1)


### PR DESCRIPTION
This patch fixes a bug where casperjs' python launcher process won't pass along kill signals to the phantomjs subprocess. This patch works by using an exec system call which causes the phantomjs subprocess to completely replace the casperjs parent process (while maintaining the same pid). This patch also has the added benefit of saving 10 megs or so of memory because the python process is discarded.

Thank you in advance for merging this and I hope you'll forgive me for the hyperbolic title :]
