### PR TITLE
Element visibility should be verified from its computed styles

### DIFF
--- a/modules/clientutils.js
+++ b/modules/clientutils.js
@@ -546,8 +546,14 @@
          */
         this.visible = function visible(selector) {
             try {
-                var el = this.findOne(selector);
-                return el && el.style.visibility !== 'hidden' && el.offsetHeight > 0 && el.offsetWidth > 0;
+                var comp,
+                    el = this.findOne(selector);
+
+                if (el) {
+                    comp = window.getComputedStyle(el, null);
+                    return comp.visibility !== 'hidden' && comp.display !== 'none' && el.offsetHeight > 0 && el.offsetWidth > 0;
+                }
+                return false;
             } catch (e) {
                 return false;
             }


### PR DESCRIPTION
In order to tell whether an element is visible or not, both visibility and display properties should be verified from its compute styles.

problem:
looking at `el.style.visibility` is only valid if such element visibility style was set directly inline via JS or style attribute, i.e: `el.style.visibility = 'hidden'` or `<div style="visibility:hidden"></div>`
An invisible element could have empty style and yet be invisible if set via via css. e.g: `<style>div{visibility:hidden;}</style><div></div>`.

solution:
look at element computed styles (both visibility and display)
