### PR TITLE
Feature: getElementAttribute, Tester.getFailures, Tester.getPasses

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -695,6 +695,20 @@ Casper.prototype.getCurrentUrl = function getCurrentUrl() {
 };
 
 /**
+ * Retrieves the value of an attribute on the first element matching the provided CSS3 selector.
+ *
+ * @param  String  selector  A CSS3 selector
+ * @param  String  attribute  The attribute to lookup
+ * @return String  The requested DOM element
+ */
+Casper.prototype.getElementAttribute = Casper.prototype.getElementAttr = function getElementAttr(selector, attribute) {
+    "use strict";
+    return this.evaluate(function _evaluate(selector, attribute) {
+        return document.querySelector(selector).getAttribute(attribute);
+    }, { selector: selector, attribute: attribute });
+};
+
+/**
  * Retrieves boundaries for a DOM element matching the provided CSS3 selector.
  *
  * @param  String  selector  A CSS3 selector
@@ -933,32 +947,6 @@ Casper.prototype.open = function open(location, settings) {
     }, this.page.settings);
     this.resources = [];
     return this;
-};
-
-/**
- * Retrieves a DOM element matching the provided CSS3 selector.
- *
- * @param  String  selector  A CSS3 selector
- * @return HTMLElement  The requested DOM element
- */
-Casper.prototype.querySelector = function querySelector(selector) {
-    "use strict";
-    return this.evaluate(function _evaluate(selector) {
-        return window.querySelector(selector);
-    }, { selector: selector });
-};
-
-/**
- * Retrieves a NodeList of DOM elements matching the provided CSS3 selector.
- *
- * @param  String  selector  A CSS3 selector
- * @return HTMLElement[]  The requested NodeList of DOM elements
- */
-Casper.prototype.querySelectorAll = function querySelectorAll(selector) {
-    "use strict";
-    return this.evaluate(function _evaluate(selector) {
-        return window.querySelectorAll(selector);
-    }, { selector: selector });
 };
 
 /**

--- a/modules/tester.js
+++ b/modules/tester.js
@@ -572,10 +572,10 @@ var Tester = function Tester(casper, options) {
      * @return Array  casedata.cases An array of all the failed case objects
      */
     this.getFailures = function getFailures() {
-        return JSON.parse(JSON.stringify({
+        return {
             length: this.testResults.failed,
             cases: this.testResults.failures
-        }));
+        };
     };
 
     /**
@@ -586,10 +586,10 @@ var Tester = function Tester(casper, options) {
      * @return Array  casedata.cases An array of all the passed case objects
      */
     this.getPasses = function getPasses() {
-        return JSON.parse(JSON.stringify({
+        return {
             length: this.testResults.passed,
             cases: this.testResults.passes
-        }));
+        };
     };
 
     /**

--- a/tests/site/elementattribute.html
+++ b/tests/site/elementattribute.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <div class="tester testo testme" data-stuff="beautiful string"></div>
+    </body>
+</html>

--- a/tests/suites/casper/elementattribute.js
+++ b/tests/suites/casper/elementattribute.js
@@ -1,0 +1,8 @@
+casper.start('tests/site/elementattribute.html', function() {
+    this.test.comment('Casper.getElementAttribute()');
+	this.test.assertEquals(this.getElementAttribute('.testo','data-stuff'), 'beautiful string', 'Casper.getElementAttribute() works as intended');
+});
+
+casper.run(function() {
+    this.test.done();
+});

--- a/tests/suites/tester.js
+++ b/tests/suites/tester.js
@@ -106,6 +106,16 @@ casper.then(function() {
     t.assertUrlMatch(/index\.html$/, "Tester.assertUrlMatch() works as expected");
 });
 
+casper.then(function() {
+    t.comment('Tester.getFailures()');
+    t.assertEquals(typeof t.getFailures().length, "number", "Tester.getFailures() works as expected");
+
+    var passCount = t.getPasses().length;
+    t.comment('Tester.getPasses()');
+    t.assertEquals(1, 1, "Rogue assertEquals pass case");
+    t.assertEquals(t.getPasses().length, passCount + 1, "Tester.getPasses() works as expected");
+});
+
 casper.run(function() {
     t.done();
 });


### PR DESCRIPTION
Issue 1: Numerous web applications we develop make extensive use of HTML5 data attributes. As this is a pretty standard use, having a way to quickly query for them could be quite valuable (and was valuable for me).

Issue 2: For our CI environment, having preemptive control of the exit code is a big win. To enable that knowledge about failures and passes should be available before the test results culminate.

Checking the testResults object would be bad, as that has nothing that would suggest it's final.
