### PR TITLE
improve xunit output, include standard text

### DIFF
--- a/modules/tester.js
+++ b/modules/tester.js
@@ -87,7 +87,7 @@ var Tester = function Tester(casper, options) {
     });
 
     this.on('success', function onSuccess(success) {
-        this.exporter.addSuccess(fs.absolute(success.file), success.message);
+        this.exporter.addSuccess(fs.absolute(success.file), success.message || success.standard);
     });
 
     this.on('fail', function onFail(failure) {


### PR DESCRIPTION
if the standard assert-text is good enough and you have no custom message specified, console output looks okay - but the xunit output is like this:

```
<testcase classname="tests/FooTest" name="undefined">
```
