### PR TITLE
Added support for "settings" to casper.thenOpen

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -1245,10 +1245,16 @@ Casper.prototype.thenEvaluate = function thenEvaluate(fn, context) {
  * @return Casper
  * @see    Casper#open
  */
-Casper.prototype.thenOpen = function thenOpen(location, then) {
+Casper.prototype.thenOpen = function thenOpen(location, settings, then) {
     "use strict";
+    if (utils.isFunction(settings)) {
+        then = settings;
+        settings = {
+            "method": "get"
+        };
+    }
     this.then(this.createStep(function _step() {
-        this.open(location);
+        this.open(location, settings);
     }, {
         skipLog: true
     }));

--- a/tests/site/index.html
+++ b/tests/site/index.html
@@ -1,17 +1,1 @@
-<!DOCTYPE html>
-<html>
-    <head>
-        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-        <title>CasperJS test index</title>
-    </head>
-    <body>
-        <img src="images/phantom.png"/>
-        <a href="test.html">test</a>
-        <a href="form.html">form</a>
-        <ul>
-            <li>one</li>
-            <li>two</li>
-            <li>three</li>
-        </ul>
-    </body>
-</html>
+plop=42&chuck=norris

--- a/tests/suites/casper/open.js
+++ b/tests/suites/casper/open.js
@@ -22,7 +22,31 @@ var t = casper.test, current = 0, tests = [
             username: 'bob',
             password: 'sinclar'
         }, "Casper.open() used the expected HTTP auth settings");
-    }
+    },
+    function(settings) {
+        t.assertEquals(settings, {
+            method: "get"
+        }, "Casper.thenOpen() used the expected GET settings");
+    },
+    function(settings) {
+        t.assertEquals(settings, {
+            method: "post",
+            data:   "plop=42&chuck=norris"
+        }, "Casper.thenOpen() used the expected POST settings");
+    },
+    function(settings) {
+        t.assertEquals(settings, {
+            method: "put",
+            data:   "plop=42&chuck=norris"
+        }, "Casper.thenOpen() used the expected PUT settings");
+    },
+    function(settings) {
+        t.assertEquals(settings, {
+            method: "get",
+            username: 'bob',
+            password: 'sinclar'
+        }, "Casper.thenOpen() used the expected HTTP auth settings");
+    },
 ];
 
 casper.start();
@@ -65,6 +89,42 @@ casper.open('tests/site/index.html', {
     password: 'sinclar'
 }).then(function() {
     t.pass("Casper.open() can open and load a location using HTTP auth");
+});
+
+// GET with thenOpen
+casper.thenOpen('tests/site/index.html').then(function() {
+    t.pass("Casper.thenOpen() can open and load a location using GET");
+});
+
+// POST with thenOpen
+casper.thenOpen('tests/site/index.html', {
+    method: 'post',
+    data:   {
+        plop: 42,
+        chuck: 'norris'
+    }
+}).then(function() {
+    t.pass("Casper.thenOpen() can open and load a location using POST");
+});
+
+// PUT with thenOpen
+casper.thenOpen('tests/site/index.html', {
+    method: 'put',
+    data:   {
+        plop: 42,
+        chuck: 'norris'
+    }
+}).then(function() {
+    t.pass("Casper.thenOpen() can open and load a location using PUT");
+});
+
+// HTTP Auth with thenOpen
+casper.thenOpen('tests/site/index.html', {
+    method: 'get',
+    username: 'bob',
+    password: 'sinclar'
+}).then(function() {
+    t.pass("Casper.thenOpen() can open and load a location using HTTP auth");
 });
 
 casper.run(function() {


### PR DESCRIPTION
This pull request implements tests and support for the "settings" argument in thenOpen. This allows you to do such things as POST the results of your scrape to a URL of your choice. Combined with the web server introduced in phantomjs 1.5, you should be able achieve half-duplex communications between any other server-client that supports RESTful communications.
