### PR TITLE
Added support for "settings" to casper.thenOpen

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -1245,10 +1245,14 @@ Casper.prototype.thenEvaluate = function thenEvaluate(fn, context) {
  * @return Casper
  * @see    Casper#open
  */
-Casper.prototype.thenOpen = function thenOpen(location, then) {
+Casper.prototype.thenOpen = function thenOpen(location, settings, then) {
     "use strict";
+    if (!(settings && !utils.isFunction(settings))) {
+      then = settings;
+      settings = null;
+    }
     this.then(this.createStep(function _step() {
-        this.open(location);
+        this.open(location, settings);
     }, {
         skipLog: true
     }));

--- a/tests/suites/casper/open.js
+++ b/tests/suites/casper/open.js
@@ -22,7 +22,31 @@ var t = casper.test, current = 0, tests = [
             username: 'bob',
             password: 'sinclar'
         }, "Casper.open() used the expected HTTP auth settings");
-    }
+    },
+    function(settings) {
+        t.assertEquals(settings, {
+            method: "get"
+        }, "Casper.thenOpen() used the expected GET settings");
+    },
+    function(settings) {
+        t.assertEquals(settings, {
+            method: "post",
+            data:   "plop=42&chuck=norris"
+        }, "Casper.thenOpen() used the expected POST settings");
+    },
+    function(settings) {
+        t.assertEquals(settings, {
+            method: "put",
+            data:   "plop=42&chuck=norris"
+        }, "Casper.thenOpen() used the expected PUT settings");
+    },
+    function(settings) {
+        t.assertEquals(settings, {
+            method: "get",
+            username: 'bob',
+            password: 'sinclar'
+        }, "Casper.thenOpen() used the expected HTTP auth settings");
+    },
 ];
 
 casper.start();
@@ -65,6 +89,42 @@ casper.open('tests/site/index.html', {
     password: 'sinclar'
 }).then(function() {
     t.pass("Casper.open() can open and load a location using HTTP auth");
+});
+
+// GET with thenOpen
+casper.thenOpen('tests/site/index.html').then(function() {
+    t.pass("Casper.thenOpen() can open and load a location using GET");
+});
+
+// POST with thenOpen
+casper.thenOpen('tests/site/index.html', {
+    method: 'post',
+    data:   {
+        plop: 42,
+        chuck: 'norris'
+    }
+}, function() {
+    t.pass("Casper.thenOpen() can open and load a location using POST");
+});
+
+// PUT with thenOpen
+casper.thenOpen('tests/site/index.html', {
+    method: 'put',
+    data:   {
+        plop: 42,
+        chuck: 'norris'
+    }
+}, function() {
+    t.pass("Casper.thenOpen() can open and load a location using PUT");
+});
+
+// HTTP Auth with thenOpen
+casper.thenOpen('tests/site/index.html', {
+    method: 'get',
+    username: 'bob',
+    password: 'sinclar'
+}, function() {
+    t.pass("Casper.thenOpen() can open and load a location using HTTP auth");
 });
 
 casper.run(function() {


### PR DESCRIPTION
This pull request implements tests and support for the "settings" argument in thenOpen. This allows you to do such things as `POST` the results of your scrape to a URL of your choice. Combined with the web server introduced in phantomjs 1.5, you should be able achieve half-duplex communications between any other server-client that supports RESTful communications.

I added the tests to open.js, but feel free to move them to thenopen.js.

HUGE CAVEAT: There is a bug in the test suite that I have no idea how you want to fix. 

Currently when you run the test suite, there is a filter in run.js to point `casper.open()` to a local file, however the underlying phantomjs implementation of `page.openUrl()` is able to modify that file when the method is `PUT`. This means that the tests for `thenOpen()` (or even an open inside a `casper.then()` fn callback) will modify/mangle the local file, which in the case of the `open()` tests is `tests/site/index.html`. 

The problem with mangling this file is that it will cause many subsequent tests to fail. Run the test quite and then run `git diff` to see the modifications performed.

I don't know how you want to fix this bug. Locally I solved the bug by changing the file permissions to 444 with chmod, however git doesn't support file permissions on files so this isn't a transferrable solution. The simplest approach is to add a few lines to the test runner that sets that file as read-only. This is not the best solution, just the easiest. Another approach is to perform a teardown that restores that file after the open.js test file is run. Yet another approach is to actually run a web server using node.js or python that serves the tests/site files.
