### PR TITLE
Fixes #189 - Reverted/removed colorizer for default messages; tweaked formatting

### DIFF
--- a/modules/tester.js
+++ b/modules/tester.js
@@ -243,7 +243,7 @@ var Tester = function Tester(casper, options) {
     this.assertExists = this.assertExist = this.assertSelectorExists = this.assertSelectorExist = function assertExists(selector, message) {
         return this.assert(casper.exists(selector), message, {
             type: "assertExists",
-            standard: f("Found an element matching %s", this.colorize(selector, 'COMMENT')),
+            standard: f("Found an element matching: %s", selector),
             values: {
                 selector: selector
             }
@@ -261,7 +261,7 @@ var Tester = function Tester(casper, options) {
     this.assertDoesntExist = this.assertNotExists = function assertDoesntExist(selector, message) {
         return this.assert(!casper.exists(selector), message, {
             type: "assertDoesntExist",
-            standard: f("No element matching selector %s is found", this.colorize(selector, 'COMMENT')),
+            standard: f("No element found matching selector: %s", selector),
             values: {
                 selector: selector
             }
@@ -279,7 +279,7 @@ var Tester = function Tester(casper, options) {
         var currentHTTPStatus = casper.currentHTTPStatus;
         return this.assert(this.testEquals(casper.currentHTTPStatus, status), message, {
             type: "assertHttpStatus",
-            standard: f("HTTP status code is %s", this.colorize(status, 'COMMENT')),
+            standard: f("HTTP status code is: %s", status),
             values: {
                 current: currentHTTPStatus,
                 expected: status
@@ -397,7 +397,7 @@ var Tester = function Tester(casper, options) {
         var currentTitle = casper.getTitle();
         return this.assert(this.testEquals(currentTitle, expected), message, {
             type: "assertTitle",
-            standard: f('Page title is "%s"', this.colorize(expected, 'COMMENT')),
+            standard: f('Page title is: "%s"', expected),
             values: {
                 subject: currentTitle,
                 expected: expected
@@ -436,7 +436,7 @@ var Tester = function Tester(casper, options) {
         var actual = utils.betterTypeOf(subject);
         return this.assert(this.testEquals(actual, type), message, {
             type: "assertType",
-            standard: f('Subject type is "%s"', this.colorize(type, 'COMMENT')),
+            standard: f('Subject type is: "%s"', type),
             values: {
                 subject: subject,
                 type: type,


### PR DESCRIPTION
The colorized formatting produced invalid XML for casper.test.renderResults().

Tweaked for formatting so that the variable part is presented by a colon,
helping to keep it distinct now that the colorized format is taken away.

Broken XML was introduced by commit 789f60d04e1090c3e5ed2ee3943528b9fb3bc8e5.
