### PR TITLE
Add a couple assertions

### DIFF
--- a/modules/tester.js
+++ b/modules/tester.js
@@ -398,6 +398,46 @@ var Tester = function Tester(casper, options) {
     };
 
     /**
+     * Asserts that given text exists in the provided selector.
+     *
+     * @param  String   selector  Selector expression
+     * @param  String   text      Text to be found
+     * @param  String   message   Test description
+     * @return Object             An assertion result object
+     */
+    this.assertSelectorHasText = function assertSelectorHasText(selector, text, message) {
+        var textFound = casper.fetchText(selector).indexOf(text) !== -1;
+        return this.assert(textFound, message, {
+            type: "assertTextInSelector",
+            standard: f('Found %s within the selector %s', this.colorize(text, 'COMMENT'), this.colorize(selector, 'COMMENT')),
+            values: {
+                selector: selector,
+                text: text
+            }
+        });
+    };
+
+    /**
+     * Asserts that given text does not exist in the provided selector.
+     *
+     * @param  String   selector  Selector expression
+     * @param  String   text      Text not to be found
+     * @param  String   message   Test description
+     * @return Object             An assertion result object
+     */
+    this.assertSelectorDoesntHaveText = function assertSelectorDoesntHaveText(selector, text, message) {
+        var textFound = casper.fetchText(selector).indexOf(text) === -1;
+        return this.assert(textFound, message, {
+            type: "assertNoTextInSelector",
+            standard: f('Did not find %s within the selector %s', this.colorize(text, 'COMMENT'), this.colorize(selector, 'COMMENT')),
+            values: {
+                selector: selector,
+                text: text
+            }
+        });
+    };
+
+    /**
      * Asserts that title of the remote page equals to the expected one.
      *
      * @param  String  expected  The expected title string

--- a/tests/site/index.html
+++ b/tests/site/index.html
@@ -14,5 +14,6 @@
             <li>three</li>
         </ul>
         <input type="text" name="dummy_name" value="dummy_value" />
+        <h1>Title</h1>
     </body>
 </html>

--- a/tests/suites/tester.js
+++ b/tests/suites/tester.js
@@ -50,6 +50,12 @@ casper.thenOpen('tests/site/index.html', function() {
 
     t.comment('Tester.assertTextExists()');
     t.assertTextExists('form', 'Tester.assertTextExists() checks that page body contains text');
+
+    t.comment('Tester.assertSelectorHasText()');
+    t.assertSelectorHasText('h1', 'Title', 'Tester.assertSelectorHasText() works as expected');
+
+    t.comment('Tester.assertSelectorDoesntHaveText()');
+    t.assertSelectorDoesntHaveText('h1', 'Subtitle', 'Tester.assertSelectorDoesntHaveText() works as expected');
 });
 
 casper.then(function() {


### PR DESCRIPTION
This branch adds three new assertions to the Tester module:

``` js
// Asserts that a given input field has the provided value.
test.assertField(input_name, expected_value, message) 
```

``` js
// Asserts that given text exists in the provided selector.
test.assertSelectorHasText(selector, text, message)
```

``` js
// Asserts that given text does not exist in the provided selector.
test.assertSelectorDoesntHaveText(selector, text, message)
```

Passing tests included.
