### PR TITLE
Fix test status timeouts when running multiple suites

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -1087,7 +1087,7 @@ Casper.prototype.runStep = function runStep(step) {
     if (utils.isNumber(this.options.stepTimeout) && this.options.stepTimeout > 0) {
         var stepTimeoutCheckInterval = setInterval(function _check(self, start, stepNum) {
             if (new Date().getTime() - start > self.options.stepTimeout) {
-                if (self.step === stepNum) {
+                if ((self.test.currentSuiteNum + "-" + self.step) === stepNum) {
                     self.emit('step.timeout');
                     if (utils.isFunction(self.options.onStepTimeout)) {
                         self.options.onStepTimeout.call(self, self);
@@ -1097,7 +1097,7 @@ Casper.prototype.runStep = function runStep(step) {
                 }
                 clearInterval(stepTimeoutCheckInterval);
             }
-        }, this.options.stepTimeout, this, new Date().getTime(), this.step);
+        }, this.options.stepTimeout, this, new Date().getTime(), this.test.currentSuiteNum + "-" + this.step);
     }
     this.emit('step.start', step);
     stepResult = step.call(this, this);

--- a/modules/tester.js
+++ b/modules/tester.js
@@ -54,6 +54,7 @@ var Tester = function Tester(casper, options) {
     }
 
     this.currentTestFile = null;
+    this.currentSuiteNum = 0;
     this.exporter = require('xunit').create();
     this.includes = [];
     this.running = false;
@@ -738,17 +739,17 @@ var Tester = function Tester(casper, options) {
             this.bar(f("No test file found in %s, aborting.", Array.prototype.slice.call(arguments)), "RED_BAR");
             casper.exit(1);
         }
-        var current = 0;
+        self.currentSuiteNum = 0;
         var interval = setInterval(function _check(self) {
             if (self.running) {
                 return;
             }
-            if (current === testFiles.length) {
+            if (self.currentSuiteNum === testFiles.length) {
                 self.emit('tests.complete');
                 clearInterval(interval);
             } else {
-                self.runTest(testFiles[current]);
-                current++;
+                self.runTest(testFiles[self.currentSuiteNum]);
+                self.currentSuiteNum++;
             }
         }, 100, this);
     };


### PR DESCRIPTION
https://github.com/n1k0/casperjs/issues/201

---

casperjs - line 1088 - the stepTimeoutCheckInterval only checks the step number and does not take into account multiple test files. When running a series of suites the step numbers overlap.

if (self.step === stepNum) - needs to take account of which suite is currently running.
