### PR TITLE
Submit buttons onclick support for casper.fill

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -657,6 +657,28 @@ Casper.prototype.fill = function fill(selector, vals, submit) {
             var form = window.__utils__.findOne(selector);
             var method = (form.getAttribute('method') || "GET").toUpperCase();
             var action = form.getAttribute('action') || "unknown";
+            
+            // Support for onclick on submit buttons
+            // Selectors to match from best to worst
+            var submitSelectors = ['button[type="submit"]', 'input[type="submit"]', 'button', 'input[type="button"]'];
+            for(var i = 0; i < submitSelectors.length; i++) {
+                var submitButton = form.querySelector(submitSelectors[i]);
+                if(submitButton) {
+                    // Doesn't work onclick function takes too long to execute so form is submitted before it finishes
+                    /*var clickEvent = document.createEvent('MouseEvent');
+                    clickEvent.initEvent('click', true, false);
+                    submitButton.dispatchEvent(click);*/
+
+                    // Doesn't work either
+                    //window.__utils__.click(selector + ' ' + submitSelectors[i]);
+
+                    if(submitButton.onclick) {
+                        submitButton.onclick();
+                    }
+                    break;
+                }
+            }
+
             window.__utils__.log('submitting form to ' + action + ', HTTP ' + method, 'info');
             if (typeof form.submit === "function") {
                 form.submit();


### PR DESCRIPTION
Calls the onclick on submit buttons before submitting the form in casper.fill.

I know some of these aren't technically submit buttons (`button`, `input[type="button"]`), but I've seen a site using `input[type="button"]` as a submit button in a form.
