### PR TITLE
Fix for when the url is changed via javascript

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -1639,6 +1639,7 @@ function createPage(casper) {
             }
             message += ': ' + casper.requestUrl;
             casper.log(message, "warning");
+            casper.navigationRequested = false;
             if (utils.isFunction(casper.options.onLoadError)) {
                 casper.options.onLoadError.call(casper, casper, casper.requestUrl, status);
             }


### PR DESCRIPTION
When the page changes location via javascript onLoadStarted is not called - casper.then does not wait for the page to finish loading before going to the next step. This is most likely due to a bug in phantomjs. 
