### PR TITLE
Encoding binary file download POST parameters

### DIFF
--- a/modules/clientutils.js
+++ b/modules/clientutils.js
@@ -314,7 +314,7 @@
                     if (typeof data === "object") {
                         var dataList = [];
                         for (var k in data) {
-                            dataList.push(escape(k) + "=" + escape(data[k].toString()));
+                            dataList.push(encodeURIComponent(k) + "=" + encodeURIComponent(data[k].toString()));
                         }
                         dataString = dataList.join('&');
                         this.log("getBinary(): Using request data: '" + dataString + "'", "debug");


### PR DESCRIPTION
When using casper.download() with unicode characters (é, á, ç, etc), sometimes it just garbled the response data and other times the request completely failed.
When replacing escape (https://github.com/n1k0/casperjs/blob/master/modules/clientutils.js#L317) by encodeURIComponent the issue is gone.

Not sure if it covers all the cases, but it works for me.

In any case, it could help someone else, so here it goes the pull request.
