### PR TITLE
Windows Loader written in Batch

### DIFF
--- a/batchbin/casperjs.bat
+++ b/batchbin/casperjs.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
-set CASPER_BIN=%~dp0
 set CASPER_PATH=%~dp0..\
+set CASPER_BIN=%CASPER_PATH%bin\
 
 set PHANTOMJS_NATIVE_ARGS=(--cookies-file --config --debug --disk-cache --ignore-ssl-errors --load-images --load-plugins --local-storage-path --local-storage-quota --local-to-remote-url-access --max-disk-cache-size --output-encoding --proxy --proxy-auth --proxy-type --remote-debugger-port --remote-debugger-autorun --script-encoding --web-security)
 


### PR DESCRIPTION
This provides a loader similar in function to the Ruby and Python loader, but setup for windows.

After adding phantomjs to the windows Path variable as well as casperjs/batchbin to the windows Path variable, this should work as it would on OSX. "casperjs <ARGS>"

Although a lot of our web engineers use OS X, the vast majority of our DevQA prefer Windows, so this is vital for enterprise inclusion.
