### PR TITLE
Assertion: assertVisible() helper method

### DIFF
--- a/modules/tester.js
+++ b/modules/tester.js
@@ -541,7 +541,7 @@ var Tester = function Tester(casper, options) {
      * @param  String  message   Test description
      * @return Object            An assertion result object
      */
-    this.assertVisible = function assertType(selector, message) {
+    this.assertVisible = function assertVisible(selector, message) {
         return this.assert(casper.visible(selector), message, {
             type: "assertVisible",
             standard: "Selector is visible",


### PR DESCRIPTION
Apologies if I'm approaching this wrongly, but I've found myself writing a lot of _if (this.visible(x)) else_ statements when writing tests, and thought it would be helpful to have a specific "assertVisible" method.

I've added the method to the tester.js module. I wasn't sure if it needed a specific test written as it's essentially just returns the result of casper.visible().

Thanks,

Donovan
