### PR TITLE
Added start script for Windows

### DIFF
--- a/bin/casperjs
+++ b/bin/casperjs
@@ -54,7 +54,13 @@ CASPER_COMMAND.extend([
 CASPER_COMMAND.extend(CASPER_ARGS)
 
 try:
-    os.execvp(CASPER_COMMAND[0], CASPER_COMMAND)
+    if os.name == 'nt':
+        import subprocess
+        proc = subprocess.Popen(CASPER_COMMAND)
+        proc.communicate()
+        sys.exit(proc.returncode)
+    else:
+        os.execvp(CASPER_COMMAND[0], CASPER_COMMAND)
 except OSError as err:
-    print(('Fatal: %s; did you install phantomjs?' % err))
+    print(('Fatal: %s; did you install phantomjs? If necessary, set PHANTOMJS_EXECUTABLE.' % err))
     sys.exit(1)

--- a/bin/casperjs.cmd
+++ b/bin/casperjs.cmd
@@ -1,0 +1,1 @@
+@python "%~dp0\casperjs" %*


### PR DESCRIPTION
This adds a batch file for starting casperjs on Windows (requires installed Python in the PATH). It also changes the use of os.exec to subprocess (only on Windows) so that the correct exit code is returned instead of starting casperjs in the background.

One only has to add the casperjs\bin folder to the PATH and running on Windows becomes as simple as

```
set PHANTOMJS_EXECUTABLE=Path\To\phantomjs-1.7.0-windows\phantomjs.exe
casperjs <script>
```
