### PR TITLE
refs #283 Added test and implementation for `assertTextDoesntExist`

### DIFF
--- a/modules/tester.js
+++ b/modules/tester.js
@@ -440,6 +440,27 @@ Tester.prototype.assertTextExists = Tester.prototype.assertTextExist = function 
 };
 
 /**
+ * Asserts that given text doesn't exist in the document body.
+ *
+ * @param  String  text     Text not to be found
+ * @param  String  message  Test description
+ * @return Object           An assertion result object
+ */
+Tester.prototype.assertTextDoesntExist = Tester.prototype.assertTextExist = function assertTextDoesntExist(text, message) {
+    "use strict";
+    var textNotFound = (this.casper.evaluate(function _evaluate() {
+        return document.body.textContent || document.body.innerText;
+    }).indexOf(text) == -1);
+    return this.assert(textNotFound, message, {
+        type: "assertTextDoesntExist",
+        standard: "Didn't find unexpected text within the document body",
+        values: {
+            text: text
+        }
+    });
+};
+
+/**
  * Asserts that given text exists in the provided selector.
  *
  * @param  String   selector  Selector expression

--- a/tests/suites/tester.js
+++ b/tests/suites/tester.js
@@ -25,6 +25,9 @@ casper.thenOpen('tests/site/index.html', function() {
     t.comment('Tester.assertTextExists()');
     t.assertTextExists('form', 'Tester.assertTextExists() checks that page body contains text');
 
+    t.comment('Tester.assertTextDoesntExist()');
+    t.assertTextDoesntExist('morf', 'Tester.assertTextDoesntExist() checks that page body doesn\'t contain certain text');
+
     t.comment('Tester.assertSelectorHasText()');
     t.assertSelectorHasText('h1', 'Title', 'Tester.assertSelectorHasText() works as expected');
 


### PR DESCRIPTION
This is a simple implementation of a missing function. It's based off `1.0.0-RC4` because the tests pass for me there but don't on `master` (although the patch applies cleanly there, the other tests don't all pass when running directly on `master`)
