### PR TITLE
ref #295 - Adding fallback to casperScript name for xunit module.

### DIFF
--- a/modules/xunit.js
+++ b/modules/xunit.js
@@ -55,6 +55,12 @@ function generateClassName(classname) {
     if (~script.indexOf('.')) {
         script = script.substring(0, script.lastIndexOf('.'));
     }
+
+    // If we have trimmed our string down to nothing, default to script name
+    if (!script && phantom.casperScript) {
+      script = phantom.casperScript;
+    }
+
     return script || "unknown";
 }
 


### PR DESCRIPTION
In the xunit module, fallback to casperScript name if the final value of the script string is empty.
