### PR TITLE
refs #209 - added time attribute to testsuite and testcases in xunit xml

### DIFF
--- a/modules/tester.js
+++ b/modules/tester.js
@@ -81,25 +81,39 @@ var Tester = function Tester(casper, options) {
         passed: 0,
         failed: 0,
         passes: [],
-        failures: []
+        failures: [],
+        passesTime: [],
+        failuresTime: []
     };
+    
+    // measuring test duration
+    this.currentTestStartTime = null;
+    this.lastAssertTime = 0;
 
     this.configure();
 
     this.on('success', function onSuccess(success) {
         this.testResults.passes.push(success);
-        this.exporter.addSuccess(fs.absolute(success.file), success.message || success.standard);
+        var timeElapsed = new Date() - this.currentTestStartTime;
+        this.testResults.passesTime.push(timeElapsed - this.lastAssertTime);
+        this.exporter.addSuccess(fs.absolute(success.file), success.message || success.standard, timeElapsed - this.lastAssertTime);
+        this.lastAssertTime = timeElapsed;
     });
 
     this.on('fail', function onFail(failure) {
         // export
+        var timeElapsed = new Date() - this.currentTestStartTime;
+        this.testResults.failuresTime.push(timeElapsed - this.lastAssertTime);
         this.exporter.addFailure(
-            fs.absolute(failure.file),
-            failure.message  || failure.standard,
-            failure.standard || "test failed",
-            failure.type     || "unknown"
-        );
+                fs.absolute(failure.file),
+                failure.message  || failure.standard,
+                failure.standard || "test failed",
+                failure.type     || "unknown",
+                (timeElapsed - this.lastAssertTime)
+            );
+        this.lastAssertTime = timeElapsed;
         this.testResults.failures.push(failure);
+
         // special printing
         if (failure.type) {
             this.comment('   type: ' + failure.type);
@@ -687,6 +701,26 @@ Tester.prototype.bar = function bar(text, style) {
 };
 
 /**
+ * Retrieves the sum of all durations of the tests which were
+ * executed in the current suite
+ *
+ * @return Number duration of all tests executed until now (in the current suite)
+ */
+Tester.prototype.calculateSuiteDuration = function calculateSuiteDuration() {
+	var sum = 0,
+	    sumArray = function(array) {
+		for(var i = 0; i < array.length; i++) {
+			sum += array[i];
+		}
+	};
+	
+	sumArray(this.testResults.passesTime);
+	sumArray(this.testResults.failuresTime);
+	
+	return sum;
+};
+
+/**
  * Render a colorized output. Basically a proxy method for
  * Casper.Colorizer#colorize()
  */
@@ -860,6 +894,25 @@ Tester.prototype.getPasses = function getPasses() {
 };
 
 /**
+ * Retrieves the array where all the durations of failed tests are stored
+ *
+ * @return Array durations of failed tests
+ */
+Tester.prototype.getFailuresTime = function getFailuresTime() {
+	return this.testResults.failuresTime;
+}
+
+/**
+ * Retrieves the array where all the durations of passed tests are stored
+ *
+ * @return Array durations of passed tests
+ */
+Tester.prototype.getPassesTime = function getPassesTime() {
+	return this.testResults.passesTime;
+}
+
+
+/**
  * Writes an info-style formatted message to stdout.
  *
  * @param  String  message
@@ -1008,6 +1061,8 @@ Tester.prototype.runSuites = function runSuites() {
         this.casper.exit(1);
     }
     self.currentSuiteNum = 0;
+    self.currentTestStartTime = new Date();
+    self.lastAssertTime = 0;
     var interval = setInterval(function _check(self) {
         if (self.running) {
             return;
@@ -1015,9 +1070,13 @@ Tester.prototype.runSuites = function runSuites() {
         if (self.currentSuiteNum === testFiles.length) {
             self.emit('tests.complete');
             clearInterval(interval);
+            self.exporter.setSuiteDuration(self.calculateSuiteDuration());
         } else {
             self.runTest(testFiles[self.currentSuiteNum]);
+            self.exporter.setSuiteDuration(self.calculateSuiteDuration());
             self.currentSuiteNum++;
+            self.passesTime = [];
+            self.failuresTime = [];
         }
     }, 100, this);
 };

--- a/modules/xunit.js
+++ b/modules/xunit.js
@@ -92,13 +92,22 @@ exports.XUnitExporter = XUnitExporter;
  *
  * @param  String  classname
  * @param  String  name
+ * @param  Number duration
  */
-XUnitExporter.prototype.addSuccess = function addSuccess(classname, name) {
+XUnitExporter.prototype.addSuccess = function addSuccess(classname, name, duration) {
     "use strict";
-    this._xml.appendChild(utils.node('testcase', {
-        classname: generateClassName(classname),
-        name:      name
-    }));
+    if(duration !== undefined) {
+        this._xml.appendChild(utils.node('testcase', {
+            classname: generateClassName(classname),
+            name: name,
+            time: duration
+        }));    	
+    } else { 
+        this._xml.appendChild(utils.node('testcase', {
+            classname: generateClassName(classname),
+            name:      name
+        }));
+    }
 };
 
 /**
@@ -108,19 +117,43 @@ XUnitExporter.prototype.addSuccess = function addSuccess(classname, name) {
  * @param  String  name
  * @param  String  message
  * @param  String  type
+ * @param  Number duration
  */
-XUnitExporter.prototype.addFailure = function addFailure(classname, name, message, type) {
+XUnitExporter.prototype.addFailure = function addFailure(classname, name, message, type, duration) {
     "use strict";
-    var fnode = utils.node('testcase', {
-        classname: generateClassName(classname),
-        name:      name
-    });
+    if(duration !== undefined) { 
+        var fnode = utils.node('testcase', {
+            classname: generateClassName(classname),
+            name:      name,
+            time: duration
+        });
+    } else {
+	    var fnode = utils.node('testcase', {
+	        classname: generateClassName(classname),
+	        name:      name
+	    });
+    	
+    }
     var failure = utils.node('failure', {
         type: type || "unknown"
     });
     failure.appendChild(document.createTextNode(message || "no message left"));
     fnode.appendChild(failure);
     this._xml.appendChild(fnode);
+};
+
+/**
+ * Adds a successful test result.
+ *
+ * @param  String  classname
+ * @param  String  name
+ * @param  Number duration
+ */
+XUnitExporter.prototype.setSuiteDuration = function setSuiteDuration(duration) {
+    "use strict";
+    if(!isNaN(duration)) {
+    	this._xml.setAttribute("time", duration);
+    }
 };
 
 /**

--- a/tests/suites/tester.js
+++ b/tests/suites/tester.js
@@ -210,6 +210,24 @@ casper.then(function() {
     t.assertEquals(t.getPasses().length, passCount + 1, "Tester.getPasses() works as expected");
 });
 
+casper.then(function() {
+	t.comment('Tester.calculateSuiteDuration()');
+	var passedTimes = t.getPassesTime(),
+		failedTimes = t.getFailuresTime(),
+		calculatedSum = t.calculateSuiteDuration(),
+		sum = 0;
+	
+		for(var i = 0; i < passedTimes.length; i++) {
+			sum += passedTimes[i];
+		}
+
+		for(var i = 0; i < failedTimes.length; i++) {
+			sum += failedTimes[i];
+		}
+		
+		t.assertEquals(calculatedSum, sum, "Tester.calculateSuiteDuration() works as expected")
+});
+
 casper.run(function() {
-    t.done(58);
+    t.done(59);
 });

--- a/tests/suites/xunit.js
+++ b/tests/suites/xunit.js
@@ -15,4 +15,18 @@ casper.test.assertMatch(xunit.getXML(), /<testcase classname="(.*)plop" name="It
 xunit.addSuccess(require('fs').workingDirectory + '/plip.js', 'Failure');
 casper.test.assertMatch(xunit.getXML(), /<testcase classname="(.*)plip" name="Failure"/, 'XUnitExporter.addFailure() handles class name');
 
-casper.test.done(4);
+// named with time
+xunit = require('xunit').create();
+xunit.addSuccess('foo', 'It worked', 1024);
+casper.test.assertMatch(xunit.getXML(), /<testcase classname="foo" name="It worked" time="(.*)"/, 'XUnitExporter.addSuccess() writes duration of test');
+xunit.addFailure('bar', 'baz', 'wrong', 'chucknorriz', 1024);
+casper.test.assertMatch(xunit.getXML(), /<testcase classname="bar" name="baz" time="(.*)"><failure type="chucknorriz">wrong/, 'XUnitExporter.addFailure() adds a failed testcase with duration');
+
+
+//named with time
+xunit = require('xunit').create();
+casper.test.assertMatch(xunit.getXML(), /<testsuite>/, 'XUnitExporter.create() created <testsuite> without time');
+xunit.setSuiteDuration(1024);
+casper.test.assertMatch(xunit.getXML(), /<testsuite time="1024">/, 'XUnitExporter.setSuiteDuration() set time');
+
+casper.test.done(8);


### PR DESCRIPTION
Added "time"-attribute to the tags `<testsuite>` and `<testcase>`.
The `time`-attribute of the tag `<testsuite>` consists of the summary of all `<testcase>` `time`-attributes.

There were also tests added for this functionality.
