### PR TITLE
Fixed: onPageInitialized callback

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -2016,7 +2016,7 @@ function createPage(casper) {
     page.onInitialized = function onInitialized() {
         casper.emit('page.initialized', this);
         if (utils.isFunction(casper.options.onPageInitialized)) {
-            this.log("Post-configuring WebPage instance", "debug");
+            casper.log("Post-configuring WebPage instance", "debug");
             casper.options.onPageInitialized.call(casper, page);
         }
     };


### PR DESCRIPTION
onPageInitialized could not be invoked.

I have not tested a fix, but I've decided to send it immediately to prevent this bug appearance within the upcoming 1.0.0 release.
