### PR TITLE
Removed extra error from ruby on incorrect exiting

### DIFF
--- a/rubybin/casperjs
+++ b/rubybin/casperjs
@@ -59,4 +59,4 @@ if system(CASPER_COMMAND.join(" ")).nil?
     puts "Fatal: Did you install phantomjs?"
 end
 
-exit $?.exitstatus
+exit $?.exitstatus || 1


### PR DESCRIPTION
When phantomjs process was interrupted (i.e. ith ^C) it's exitstatus is
nil, so `exit` function prints useless error message about nil to int
conversion.

Now explicitly exit with 1, which is a default ruby exit behaviour and
stays in sync with a python bin script.

This commit removes this:

```
[info] [phantom] ...
^C//opt/casperjs/rubybin/casperjs:62:in `exit': no implicit conversion from nil to integer (TypeError)
    from /opt/casperjs/rubybin/casperjs:62:in `<main>'
```
