### PR TITLE
Bugfix: `getFormvalues` choked on >1 form with same field names.

### DIFF
--- a/modules/clientutils.js
+++ b/modules/clientutils.js
@@ -455,10 +455,12 @@
          * Retrieves the value of a form field.
          *
          * @param  String  inputName  The for input name attr value
+         * @param  Object  options    Object with formSelector, optional
          * @return Mixed
          */
-        this.getFieldValue = function getFieldValue(inputName) {
+        this.getFieldValue = function getFieldValue(inputName, options) {
             function getSingleValue(input) {
+                var type;
                 try {
                     type = input.getAttribute('type').toLowerCase();
                 } catch (e) {
@@ -474,6 +476,7 @@
                 return input.checked;
             }
             function getMultipleValues(inputs) {
+                var type;
                 type = inputs[0].getAttribute('type').toLowerCase();
                 if (type === 'radio') {
                     var value;
@@ -491,7 +494,11 @@
                     return values;
                 }
             }
-            var inputs = this.findAll('[name="' + inputName + '"]'), type;
+            var formSelector = '';
+            if (options && options.formSelector) {
+              formSelector = options.formSelector + ' ';
+            }
+            var inputs = this.findAll(formSelector + '[name="' + inputName + '"]');
             switch (inputs.length) {
                 case 0:  return null;
                 case 1:  return getSingleValue(inputs[0]);
@@ -512,7 +519,7 @@
             [].forEach.call(form.elements, function(element) {
                 var name = element.getAttribute('name');
                 if (name && !values[name]) {
-                    values[name] = self.getFieldValue(name);
+                    values[name] = self.getFieldValue(name, {formSelector: selector});
                 }
             });
             return values;

--- a/tests/suites/casper/formfill.js
+++ b/tests/suites/casper/formfill.js
@@ -65,13 +65,21 @@ casper.test.begin('unexistent fields', 1, function(test) {
     });
 });
 
-casper.test.begin('multiple forms', 1, function(test) {
+casper.test.begin('multiple forms', 2, function(test) {
     casper.start('tests/site/multiple-forms.html', function() {
         this.fill('form[name="f2"]', {
             yo: "ok"
         }, true);
     }).then(function() {
         test.assertUrlMatch(/\?f=f2&yo=ok$/, 'Casper.fill() handles multiple forms');
+    }).then(function() {
+        this.fill('form[name="f2"]', {
+            yo: "ok"
+        });
+        test.assertEquals(this.getFormValues('form[name="f2"]'), {
+            f: "f2",
+            yo: "ok"
+        }, 'Casper.getFormValues() retrieves filled values when multiple forms have same field names');
     }).run(function() {
         test.done();
     });


### PR DESCRIPTION
This commit addresses an issue where if a document had more than one form, and there was overlap in field names across forms, `getFormValues` would not return the correct result.

The fix is to pass a scope to `getFieldValue` so it only attempts to retrieve values for fields in the given form.
