### PR TITLE
Check that user-agent header exists before retrieving it

### DIFF
--- a/tests/suites/casper/agent.js
+++ b/tests/suites/casper/agent.js
@@ -14,7 +14,7 @@ function fetchUA(request) {
     testUA(headers.pop().value, /plop/);
 }
 
-casper.test.begin('userAgent() tests', 2, function(test) {
+casper.test.begin('userAgent() tests', 3, function(test) {
     testUA(casper.options.pageSettings.userAgent, /CasperJS/);
     casper.start();
     casper.userAgent('plop').once('resource.requested', fetchUA);


### PR DESCRIPTION
This converts an exception:

<pre>
rvm@reactor casperjs % ./bin/casperjs selftest tests/suites/casper/agent.js                 
Test file: tests/suites/casper/agent.js                                         
# userAgent() tests
PASS Default user agent matches /CasperJS/
FAIL TypeError: 'undefined' is not an object (evaluating 'request.headers.filter(function(header) {
        return header.name === "User-Agent";
    }).pop().value')
#    type: uncaughtError
#    file: tests/suites/casper/agent.js:12
#    error: 'undefined' is not an object (evaluating 'request.headers.filter(function(header) {
        return header.name === "User-Agent";
    }).pop().value')
#           TypeError: 'undefined' is not an object (evaluating 'request.headers.filter(function(header) {
#                   return header.name === "User-Agent";
#               }).pop().value')
#               at fetchUA (tests/suites/casper/agent.js:12)
#               at g (:170)
#               at emit (:80)
#               at onResourceRequested (:2142)
#    stack: not provided
�������userAgent() tests: 2 tests planned, 1 tests executed
FAIL 3 tests executed in 0.213s, 1 passed, 2 failed.                            

Details for the 2 failed tests:

In tests/suites/casper/agent.js:12
  userAgent() tests
    uncaughtError: TypeError: 'undefined' is not an object (evaluating 'request.headers.filter(function(header) {
        return header.name === "User-Agent";
    }).pop().value')
In tests/suites/casper/agent.js
  userAgent() tests
    dubious: userAgent() tests: 2 tests planned, 1 tests executed
</pre>


into a failure:

<pre>
rvm@reactor casperjs % ./bin/casperjs selftest tests/suites/casper/agent.js
Test file: tests/suites/casper/agent.js                                         
# userAgent() tests
PASS Default user agent matches /CasperJS/
FAIL Subject is strictly true
#    type: assert
#    file: tests/suites/casper/agent.js:13
#    code: casper.test.assert(headers.length > 0);
#    subject: false
FAIL 2 tests executed in 0.213s, 1 passed, 1 failed.                            

Details for the 1 failed test:

In tests/suites/casper/agent.js:13
  userAgent() tests
    assert: Subject is strictly true
</pre>


What to do with the failure I do not know.
