### PR TITLE
Fix phantomjs version check

### DIFF
--- a/bin/bootstrap.js
+++ b/bin/bootstrap.js
@@ -86,7 +86,7 @@ CasperError.prototype = Object.getPrototypeOf(new Error());
         if (version.minor < 8) {
             return __die('CasperJS needs at least PhantomJS v1.8 or later.');
         }
-        if (version.patch < 1) {
+        if (version.minor == 8 && version.patch < 1) {
             return __die('CasperJS needs at least PhantomJS v1.8.1 or later.');
         }
     })(phantom.version);


### PR DESCRIPTION
Patch version is checked for all minor versions >= 8, therefore
when checking for 1.8.x patch version minor needs to be checked
against 8 again.

Fixes issue #394
