### PR TITLE
.waitFor stuff for hash-based URLs doesn’t work

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -2203,7 +2203,7 @@ function createPage(casper) {
     page.onNavigationRequested = function onNavigationRequested(url, type, lock, isMainFrame) {
         casper.log(f('Navigation requested: url=%s, type=%s, lock=%s, isMainFrame=%s',
                      url, type, lock, isMainFrame), "debug");
-        if (isMainFrame) {
+        if (isMainFrame && casper.requestUrl !== url) {
             casper.navigationRequested  = true;
         }
         casper.emit('navigation.requested', url, type, lock, isMainFrame);


### PR DESCRIPTION
In `page.onNavigationRequested` we set `casper.navigationRequested` to `true` only when we’re on a different URL.

Otherwise, .runStep wouldn't procceed with .waitFor stuff (for hash-based URL where you were redirected).
