### PR TITLE
#225 - Raw CLI casting

### DIFF
--- a/modules/cli.js
+++ b/modules/cli.js
@@ -108,7 +108,7 @@ exports.parse = function parse(phantomArgs) {
         } else {
             // positional arg
             extract.args.push(castArgument(arg));
-            extract.raw.args.push(castArgument(arg));
+            extract.raw.args.push(arg);
         }
     });
     extract.raw = utils.mergeObjects(extract.raw, {


### PR DESCRIPTION
Stop cli.parse(phantomArgs) from casting raw positional arguments
