### PR TITLE
refs #425 Log now has the step function name

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -1383,7 +1383,7 @@ Casper.prototype.runStep = function runStep(step) {
     /*jshint maxstatements:20*/
     this.checkStarted();
     var skipLog = utils.isObject(step.options) && step.options.skipLog === true,
-        stepInfo = f("Step %s %d/%d", step.name, this.step, this.steps.length),
+        stepInfo = f("Step %s %d/%d", step.name || "anonymous", this.step, this.steps.length),
         stepResult;
     function getCurrentSuiteId(casper) {
         try {


### PR DESCRIPTION
Now the log messages have step function name if available.

``` js
casper.start('http://www.foo.com/property/loginpage.php', function login() {
  this.fill('form', { username: 'abc', password: 'xyz'}, true);
});
```

then the log will look like

```
Step login (2/15) http://www.foo.com/property/loginpage.php (HTTP 200)
```

if the function is not named then it will look (note the extra spaces)

```
Step  (2/15) http://www.foo.com/property/loginpage.php (HTTP 200)
```
