### PR TITLE
add new parameter settings to sendAJAX function

### DIFF
--- a/docs/modules/clientutils.rst
+++ b/docs/modules/clientutils.rst
@@ -315,7 +315,7 @@ Removes all DOM elements matching a given :ref:`XPath expression <selectors>`.
 ``sendAJAX()``
 -----------------------------------------------------------------------------
 
-**Signature:** ``sendAJAX(String url[, String method, Object data, Boolean async])``
+**Signature:** ``sendAJAX(String url[, String method, Object data, Boolean async, Object settings])``
 
 .. versionadded:: 1.0
 
@@ -325,6 +325,7 @@ Sends an AJAX request, using the following parameters:
 - ``method``: The HTTP method (default: ``GET``).
 - ``data``: Request parameters (default: ``null``).
 - ``async``: Flag for an asynchroneous request? (default: ``false``)
+- ``settings``: Other settings when perform the AJAX request (default: ``null``)
 
 .. warning::
 

--- a/modules/clientutils.js
+++ b/modules/clientutils.js
@@ -628,17 +628,19 @@
         /**
          * Performs an AJAX request.
          *
-         * @param   String   url     Url.
-         * @param   String   method  HTTP method (default: GET).
-         * @param   Object   data    Request parameters.
-         * @param   Boolean  async   Asynchroneous request? (default: false)
-         * @return  String           Response text.
+         * @param   String   url      Url.
+         * @param   String   method   HTTP method (default: GET).
+         * @param   Object   data     Request parameters.
+         * @param   Boolean  async    Asynchroneous request? (default: false)
+         * @param   Object   settings Other settings when perform the ajax request
+         * @return  String            Response text.
          */
-        this.sendAJAX = function sendAJAX(url, method, data, async) {
+        this.sendAJAX = function sendAJAX(url, method, data, async, settings) {
             var xhr = new XMLHttpRequest(),
                 dataString = "",
                 dataList = [];
             method = method && method.toUpperCase() || "GET";
+            var contentType = settings && settings.contentType || "application/x-www-form-urlencoded";
             xhr.open(method, url, !!async);
             this.log("sendAJAX(): Using HTTP method: '" + method + "'", "debug");
             xhr.overrideMimeType("text/plain; charset=x-user-defined");
@@ -652,7 +654,7 @@
                 } else if (typeof data === "string") {
                     dataString = data;
                 }
-                xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+                xhr.setRequestHeader("Content-Type", contentType);
             }
             xhr.send(method === "POST" ? dataString : null);
             return xhr.responseText;


### PR DESCRIPTION
Some sites don't accept the default content-type "application/x-www-form-urlencoded", must send out the specific content-type.
so we need the extra settings to override the default content-type setting in current sendAJAX implementation.

For back-compatible, I didn't modify the previous parameters, just add a new Object settings  as the last parameter. We can use it for storing more settings in the future if needed. 
