### PR TITLE
Make Casper.currentResponse consistent with Casper.page 

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -2268,7 +2268,7 @@ function createPage(casper) {
         if (isMainFrame && casper.requestUrl !== url) {
             casper.navigationRequested  = true;
 
-            if(willNavigate) {
+            if (willNavigate) {
                 casper.requestUrl = url;
             }
         }

--- a/tests/suites/casper/navigation.js
+++ b/tests/suites/casper/navigation.js
@@ -9,7 +9,6 @@ var service = server.listen(8090, function(request, response) {
     response.close();
 });
 
-
 casper.test.begin('Link Navigation updates response', function(test) {
     casper.start('http://localhost:8090', function(response) {
         casper.click('a');
@@ -21,7 +20,7 @@ casper.test.begin('Link Navigation updates response', function(test) {
             test.assertEquals(
                 response.url,
                 casper.page.url,
-                'response is consisitent with the internal page'
+                'response is consistent with the internal page'
             );
 
         });
@@ -41,7 +40,7 @@ casper.test.begin('Form Submittal updates the response', function(test) {
             test.assertEquals(
                 response.url,
                 casper.page.url,
-                'response is consisitent with the internal page'
+                'response is consistent with the internal page'
             );
         });
     }).run(function() {
@@ -49,4 +48,3 @@ casper.test.begin('Form Submittal updates the response', function(test) {
         server.close();
     });
 });
-


### PR DESCRIPTION
Previously, when clicking on a link in a page or submitting a form,
`Casper.page` would be updated to reflect the newly loaded page, but
`Casper.currentResponse` would not.  This caused the response passed to
'then' callbacks to only reflect the initial page load.  This patch
resolves that issue so that Casper's page and currentResponse are
consistent and subsequent 'then' callbacks receive the response of the
most recent main page load.
