### PR TITLE
allow users to indicate whether need override MimeType when performing ajax Requests

### DIFF
--- a/docs/modules/clientutils.rst
+++ b/docs/modules/clientutils.rst
@@ -343,6 +343,14 @@ Sends an AJAX request, using the following parameters:
            require('utils').dump(data);
        });
 
+   In some scenarios, we don't want to override the mimetype, you can do like this::
+
+       __utils__.sendAJAX(url, 'POST', params, false, {
+           overrideMimeType : false
+       });
+
+   otherwise, this function will always override mime type by using the default one: "text/plain; charset=x-user-defined"
+
 ``visible()``
 -------------------------------------------------------------------------------
 

--- a/modules/clientutils.js
+++ b/modules/clientutils.js
@@ -705,9 +705,12 @@
                 dataList = [];
             method = method && method.toUpperCase() || "GET";
             var contentType = settings && settings.contentType || "application/x-www-form-urlencoded";
+            var mimeType = settings && settings.mimeType || "text/plain; charset=x-user-defined";
+            var overrideMimeType = (settings && 'overrideMimeType' in settings) ? settings.overrideMimeType : true;
             xhr.open(method, url, !!async);
             this.log("sendAJAX(): Using HTTP method: '" + method + "'", "debug");
-            xhr.overrideMimeType("text/plain; charset=x-user-defined");
+            if (overrideMimeType)
+                xhr.overrideMimeType(mimeType);
             if (method === "POST") {
                 if (typeof data === "object") {
                     for (var k in data) {


### PR DESCRIPTION
Current the mimeType is fixed in the codes and already overrided,
this will block some ajaX requests which return back those like Chinese in some scenarios..
