### PR TITLE
Reuse beautiful formatting when showing error summaries

### DIFF
--- a/modules/tester.js
+++ b/modules/tester.js
@@ -1343,8 +1343,7 @@ Tester.prototype.renderFailureDetails = function renderFailureDetails() {
         if (failure.suite) {
             this.casper.echo(f('  %s', failure.suite), "PARAMETER");
         }
-        this.casper.echo(f('    %s: %s', failure.type || "unknown",
-            failure.message || failure.standard || "(no message was entered)"), "COMMENT");
+        try { this.processAssertionResult(failure); } catch(e) {}
     }.bind(this));
 };
 


### PR DESCRIPTION
If you have lined up your error messages to be easy to scan visually when a test fails, the summary at the end breaks this formatting, on behalf of not reusing the normal error formatting code.

Example screenshot from before this change:

![before](https://f.cloud.github.com/assets/2459/607425/221c7e84-cd44-11e2-89a9-5f8787270323.png)

After:

![after](https://f.cloud.github.com/assets/2459/607428/283697fa-cd44-11e2-9b71-c20df118e2c5.png)
