### PR TITLE
Add missing backslash in assertMatch example

### DIFF
--- a/docs/modules/tester.rst
+++ b/docs/modules/tester.rst
@@ -206,7 +206,7 @@ Asserts that current `HTTP status code <http://www.w3.org/Protocols/rfc2616/rfc2
 
 Asserts that a provided string matches a provided javascript ``RegExp`` pattern::
 
-    casper.test.assertMatch('Chuck Norris', /^chuck/i, 'Chuck Norris' first name is Chuck');
+    casper.test.assertMatch('Chuck Norris', /^chuck/i, 'Chuck Norris\' first name is Chuck');
 
 .. seealso::
 


### PR DESCRIPTION
Forgotten backslash breaks syntax coloration in assertMatch() example.

(Incoming PR in gh-pages as well)
