### PR TITLE
Add missing backslash in assertMatch example

### DIFF
--- a/api.html
+++ b/api.html
@@ -2473,7 +2473,7 @@ is the same as the one passed as argument.
 pattern.
 
 </p>
-<pre><code class="javascript">casper.test.assertMatch('Chuck Norris', /^chuck/i, 'Chuck Norris' first name is Chuck');</code></pre>
+<pre><code class="javascript">casper.test.assertMatch('Chuck Norris', /^chuck/i, 'Chuck Norris\' first name is Chuck');</code></pre>
 <h3 id="tester.assertNot"><code>Tester#assertNot(mixed subject[, String message])</code></h3>
 
 <p>Asserts that the passed subject resolves to some


### PR DESCRIPTION
Forgotten backslash breaks syntax coloration in assertMatch() example.

See https://github.com/n1k0/casperjs/pull/501
