### PR TITLE
Fixes #512: continue to the next step on assertion errors

### DIFF
--- a/modules/tester.js
+++ b/modules/tester.js
@@ -177,7 +177,7 @@ var Tester = function Tester(casper, options) {
         self.casper.unwait();
         if (error instanceof Error) {
             self.processError(error);
-            return self.done();
+            return;
         }
         if (utils.isString(error) && /^(Assertion|Termination|TimedOut)Error/.test(error)) {
             return;
@@ -189,6 +189,10 @@ var Tester = function Tester(casper, options) {
             })[0].line;
         } catch (e) {}
         self.uncaughtError(error, self.currentTestFile, line, backtrace);
+    }
+    
+    function errorHandlerAndDone(error, backtrace) {
+        errorHandler(error, backtrace);
         self.done();
     }
 
@@ -196,11 +200,12 @@ var Tester = function Tester(casper, options) {
         'wait.error',
         'waitFor.timeout.error',
         'event.error',
-        'step.error',
         'complete.error'
     ].forEach(function(event) {
-        self.casper.on(event, errorHandler);
+        self.casper.on(event, errorHandlerAndDone);
     });
+
+    self.casper.on('step.error', errorHandler);
 
     this.casper.on('warn', function(warning) {
         if (self.currentSuite) {


### PR DESCRIPTION
When an assertion fails, casperjs stops any steps in the current suite.
This could cause issues in a test suite. For example, "withFrame"
generates some steps:
- one to switch to the given frame
- one to execute the given tests
- one to switch to the main frame.

If tests fail, the third step is not executed, and then next tests fail
because they are not executed in the main frame.

we can saw this issue in selftests: if a test fails in tests/suites/casper/frame.js,
tests in tests/suites/casper/global.js fail too.
