### PR TITLE
Fix use of utils.format on client side code

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -1084,7 +1084,7 @@ Casper.prototype.getGlobal = function getGlobal(name) {
         try {
             result.value = JSON.stringify(window[name]);
         } catch (e) {
-            var message = f("Unable to JSON encode window.%s: %s", name, e);
+            var message = "Unable to JSON encode window." + name + ": " + e;
             __utils__.log(message, "error");
             result.error = message;
         }


### PR DESCRIPTION
Casper.getGlobal uses f, aka utils.format in code executed client side, resulting in an error message. Plain old string concatenate should fix this.
