### PR TITLE
make usable by npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "phantomjs",
     "javascript"
   ],
+  "bin": "./bin/casperjs",
   "maintainers": [
     {
       "name": "Nicolas Perriault",


### PR DESCRIPTION
This will enable installing casperjs via npm, so that e.g. grunt tasks can run the tests.
See this example: https://github.com/smlgbl/grunt-casperjs-extra
