### PR TITLE
Add SlimerJS to usage documentation

### DIFF
--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -1,4 +1,3 @@
-
 Usage: casperjs [options] script.[js|coffee] [script argument [script argument ...]]
        casperjs [options] test [test path [test path ...]]
        casperjs [options] selftest
@@ -10,6 +9,6 @@ Options:
 --log-level Sets logging level
 --help      Prints this help
 --version   Prints out CasperJS version
---engine=name Use the given engine. Current supported engine: phantomjs
+--engine=name Use the given engine. Current supported engine: phantomjs and slimerjs
 
 Read the docs http://docs.casperjs.org/


### PR DESCRIPTION
The usage documentation displayed when Casper is launched without options miss the awesome SlimerJS
