### PR TITLE
refs #562 - Fix backslashes acting as escape chars

### DIFF
--- a/batchbin/casperjs.bat
+++ b/batchbin/casperjs.bat
@@ -1,5 +1,5 @@
 @ECHO OFF
 set CASPER_PATH=%~dp0..
-set CASPER_BIN=%CASPER_PATH%\bin\
-set ARGV=%*
-call phantomjs "%CASPER_BIN%bootstrap.js" --casper-path="%CASPER_PATH%" --cli %ARGV%
+set CASPER_PATH=%CASPER_PATH:\=/%
+set CASPER_BIN=%CASPER_PATH%/bin/
+call phantomjs "%CASPER_BIN%bootstrap.js" --casper-path="%CASPER_PATH%" --cli %*


### PR DESCRIPTION
Trailing backslash in `%CASPER_PATH%` was escaping closing quote in `--casper-path`.

This changes backslashes in `%CASPER_PATH%` to forward slashes. Same with `%CASPER_BIN%` to be consistent.

I also removed superfluous `%ARGV%` variable to avoid potential problems with batch failing to properly send full cli params.
