### PR TITLE
Update python test script to work with python3

### DIFF
--- a/tests/clitests/runtests.py
+++ b/tests/clitests/runtests.py
@@ -98,6 +98,7 @@ class CasperExecTest(unittest.TestCase):
     def test_simple_test_script(self):
         script_path = os.path.join(TEST_ROOT, 'tester', 'mytest.js')
         self.assertCommandOutputContains('test ' + script_path, [
+            script_path,
             'PASS ok1',
             'PASS ok2',
             'PASS ok3',
@@ -113,6 +114,7 @@ class CasperExecTest(unittest.TestCase):
         # using begin()
         script_path = os.path.join(TEST_ROOT, 'tester', 'passing.js')
         self.assertCommandOutputContains('test ' + script_path, [
+            script_path,
             '# true',
             'PASS Subject is strictly true',
             'PASS 1 test executed',
@@ -158,6 +160,7 @@ class CasperExecTest(unittest.TestCase):
     def test_skipped_test(self):
         script_path = os.path.join(TEST_ROOT, 'tester', 'skipped.js')
         self.assertCommandOutputContains('test ' + script_path, [
+            script_path,
             'SKIP 1 test skipped',
             'PASS 1 test executed',
             '1 passed',


### PR DESCRIPTION
Allow `make` to run in environments with python3.
