### PR TITLE
Refactor to remove unnecessary entries in paths array

### DIFF
--- a/bin/bootstrap.js
+++ b/bin/bootstrap.js
@@ -189,9 +189,9 @@ CasperError.prototype = Object.getPrototypeOf(new Error());
             var extensions = ['js', 'coffee', 'json'];
             var basenames = [path, path + '/index'];
             var paths = [];
-            extensions.forEach(function(extension) {
-                basenames.forEach(function(basename) {
-                    paths.push(fs.pathJoin(dir, basename));
+            basenames.forEach(function(basename) {
+                paths.push(fs.pathJoin(dir, basename));
+                extensions.forEach(function(extension) {
                     paths.push(fs.pathJoin(dir, [basename, extension].join('.')));
                 });
             });


### PR DESCRIPTION
The latest backwards-compatibility commit ended up adding in `fs.pathJoin(dir, basename)` three times for each `basename`.

This commit adds it for each `basename` instead of each `extension` and `basename`
