### PR TITLE
XML serialization for xUnit output

### DIFF
--- a/modules/xunit.js
+++ b/modules/xunit.js
@@ -83,7 +83,8 @@ function XUnitExporter() {
     this.results = undefined;
     this._xml = utils.node('testsuites');
     this._xml.toString = function toString() {
-        return '<?xml version="1.0" encoding="UTF-8"?>' + this.outerHTML; // ouch
+        var serializer = new XMLSerializer();
+        return '<?xml version="1.0" encoding="UTF-8"?>' + serializer.serializeToString(this);
     };
 }
 exports.XUnitExporter = XUnitExporter;


### PR DESCRIPTION
To avoid breaking the XML output with specific HTML entities such as &nbsp;
