### PR TITLE
ref #637: checkStep turns into an infinite loop when navigationLocked == true

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -2435,11 +2435,12 @@ function createPage(casper) {
                 newUrl = newUrl.substring(0, pos);
             }
             // for URLs that are only different by their hash part
+            // or if navigation locked (willNavigate == false)
             // don't turn navigationRequested to true, because
             // there will not be loadStarted, loadFinished events
             // so it could cause issues (for exemple, checkStep that
             // do no execute the next step -> infinite loop on checkStep)
-            if (currentUrl !== newUrl)
+            if (willNavigate && currentUrl !== newUrl)
                 casper.navigationRequested  = true;
 
             if (willNavigate) {


### PR DESCRIPTION
Simple example:

``` JavaScript
x = require('casper').selectXPath;
casper = require('casper').create({
    verbose: true,
    logLevel: "debug"
});

casper.start('http://www.casperjs.org', function() {
  this.page.navigationLocked = true;
});

casper.thenClick(x('//a[@class="brand"]'), function() {
    this.echo('Then executed!')
});

casper.run(function() {
  this.exit();
});
```

Actual:

```
$casperjs test.js
[info] [phantom] Starting...
[info] [phantom] Running suite: 4 steps
[debug] [phantom] opening url: http://www.casperjs.org/, HTTP GET
[debug] [phantom] Navigation requested: url=http://www.casperjs.org/, type=Other, willNavigate=true, isMainFrame=true
[debug] [phantom] Navigation requested: url=http://casperjs.org/, type=Other, willNavigate=true, isMainFrame=true
[debug] [phantom] url changed to "http://casperjs.org/"
[debug] [phantom] Successfully injected Casper client-side utilities
[info] [phantom] Step anonymous 2/4 http://casperjs.org/ (HTTP 200)
[info] [phantom] Step anonymous 2/4: done in 4263ms.
[info] [phantom] Step _step 3/4 http://casperjs.org/ (HTTP 200)
[debug] [phantom] Mouse event 'mousedown' on selector: xpath selector: //a[@class="brand"]
[debug] [phantom] Mouse event 'mouseup' on selector: xpath selector: //a[@class="brand"]
[debug] [phantom] Mouse event 'click' on selector: xpath selector: //a[@class="brand"]
[debug] [phantom] Navigation requested: url=http://casperjs.org/index.html, type=LinkClicked, willNavigate=false, isMainFrame=true
[info] [phantom] Step _step 3/4: done in 4294ms.


```

Expected:

```
$casperjs test.js                      
[info] [phantom] Starting...
[info] [phantom] Running suite: 4 steps
[debug] [phantom] opening url: http://www.casperjs.org/, HTTP GET
[debug] [phantom] Navigation requested: url=http://www.casperjs.org/, type=Other, willNavigate=true, isMainFrame=true
[debug] [phantom] Navigation requested: url=http://casperjs.org/, type=Other, willNavigate=true, isMainFrame=true
[debug] [phantom] url changed to "http://casperjs.org/"
[debug] [phantom] Successfully injected Casper client-side utilities
[info] [phantom] Step anonymous 2/4 http://casperjs.org/ (HTTP 200)
[info] [phantom] Step anonymous 2/4: done in 7179ms.
[info] [phantom] Step _step 3/4 http://casperjs.org/ (HTTP 200)
[debug] [phantom] Mouse event 'mousedown' on selector: xpath selector: //a[@class="brand"]
[debug] [phantom] Mouse event 'mouseup' on selector: xpath selector: //a[@class="brand"]
[debug] [phantom] Mouse event 'click' on selector: xpath selector: //a[@class="brand"]
[debug] [phantom] Navigation requested: url=http://casperjs.org/index.html, type=LinkClicked, willNavigate=false, isMainFrame=true
[info] [phantom] Step _step 3/4: done in 7206ms.
[info] [phantom] Step anonymous 4/4 http://casperjs.org/ (HTTP 200)
Then executed!
[info] [phantom] Step anonymous 4/4: done in 7219ms.
[info] [phantom] Done 4 steps in 7238ms
```
