### PR TITLE
Change mergeObject to have option to keep references

### DIFF
--- a/docs/modules/utils.rst
+++ b/docs/modules/utils.rst
@@ -220,7 +220,7 @@ Checks if passed argument is an instance of native PhantomJS' ``WebPage`` object
 
 Merges two objects recursively.
 
-Add opts.keepReferences if cloning of internal objects is not needed.
+Add ``opts.keepReferences`` if cloning of internal objects is not needed.
 
 .. index:: DOM
 

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -641,11 +641,7 @@ function mergeObjectsInSlimerjs(origin, add, opts) {
             if (isPlainObject(origin[p])) {
                 origin[p] = mergeObjects(origin[p], add[p]);
             } else {
-                if (keepReferences) {
-                    origin[p] = add[p];
-                } else {
-                    origin[p] = clone(add[p]);
-                }
+                origin[p] = keepReferences ? add[p] : clone(add[p]);
             }
         } else {
             origin[p] = add[p];
@@ -680,11 +676,7 @@ function mergeObjects(origin, add, opts) {
             if (origin[p] && origin[p].constructor === Object) {
                 origin[p] = mergeObjects(origin[p], add[p]);
             } else {
-                if (keepReferences) {
-                    origin[p] = add[p];
-                } else {
-                    origin[p] = clone(add[p]);
-                }
+                origin[p] = keepReferences ? add[p] : clone(add[p]);
             }
         } else {
             origin[p] = add[p];

--- a/tests/suites/utils.js
+++ b/tests/suites/utils.js
@@ -327,6 +327,7 @@ casper.test.begin('isJsFile() tests', 5, function(test) {
 
 
 casper.test.begin('mergeObjects() tests', 10, function(test) {
+    /* jshint eqeqeq:false */
     var testCases = [
         {
             obj1: {a: 1}, obj2: {b: 2}, merged: {a: 1, b: 2}


### PR DESCRIPTION
Addressing https://github.com/n1k0/casperjs/issues/658. This follows @n1k0's recommendation to add the a reference to keep the references (here it is `keepReferences`).
