### PR TITLE
Improved CLI Api for verbose mode

### DIFF
--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -5,7 +5,7 @@ Usage: casperjs [options] script.[js|coffee] [script argument [script argument .
 
 Options:
 
---direct    Prints log messages to the console
+--verbose   Prints log messages to the console
 --log-level Sets logging level
 --help      Prints this help
 --version   Prints out CasperJS version

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -91,7 +91,7 @@ Execution results:
 
 The `casperjs` command has three available options:
 
-- ``--direct``: to prints out log messages to the console
+- ``--verbose``: to prints out log messages to the console
 - ``--log-level=[debug|info|warning|error]`` to set the :ref:`logging level <logging>`
 - ``--engine=[phantomjs|slimerjs]`` to select the browser engine you want to use. CasperJS
    supports PhantomJS (default) that runs Webkit, and SlimerJS that runs Gecko.
@@ -100,7 +100,7 @@ Example:
 
 .. code-block:: text
 
-    $ casperjs --direct --log-level=debug myscript.js
+    $ casperjs --verbose --log-level=debug myscript.js
 
 Last but not least, you can still use all PhantomJS standard CLI options as you would do with any other phantomjs script:
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -157,7 +157,7 @@ Options
 Options are prefixed with a double-dash (``--``):
 
 - ``--xunit=<filename>`` will export test suite results in a :ref:`XUnit XML file <xunit_report>`
-- ``--direct`` will print :doc:`log messages <logging>` directly to the console
+- ``--verbose`` will print :doc:`log messages <logging>` directly to the console
 - ``--log-level=<logLevel>`` sets the logging level (see the :doc:`related section <logging>`)
 
 .. versionadded:: 1.0
@@ -176,7 +176,7 @@ Sample custom command:
     $ casperjs test --includes=foo.js,bar.js \
                     --pre=pre-test.js \
                     --post=post-test.js \
-                    --direct \
+                    --verbose \
                     --log-level=debug \
                     --fail-fast \
                     test1.js test2.js /path/to/some/test/dir

--- a/modules/casper.js
+++ b/modules/casper.js
@@ -129,7 +129,7 @@ var Casper = function Casper(options) {
     // factories
     this.cli = phantom.casperArgs;
     this.options.logLevel = this.cli.get('log-level', this.options.logLevel);
-    this.options.verbose = this.cli.get('direct', this.options.verbose);
+    this.options.verbose = this.cli.has('verbose');
     this.colorizer = this.getColorizer();
     this.mouse = mouse.create(this);
     this.popups = pagestack.create();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [no] |
| New feature? | [no] |
| BC breaks? | [yes] |
| Deprecations? | [yes] |
| Tests pass? | [yes] |
| Fixed tickets |  |
| License | MIT |
| Doc PR | [yes] |

CasperJs have an [Cli Module](http://docs.casperjs.org/en/latest/cli.html), which is useful usually when you need to log/debug your scrapping/testing.

I don't understand why `--direct` argument match to `verbose` option so I propose this PR to fix this.

By the way, documentation has been updated in this PR, also the file `usage.txt` which has been "prompted" on CLI.
