### PR TITLE
Fix error where this.emit('error', error); doesn't exist

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -380,7 +380,7 @@ Casper.prototype.checkStep = function checkStep(self, onComplete) {
         }
     } catch (error) {
         self.emit('complete.error', error);
-        this.emit('error', error);
+        self.emit('error', error);
     }
 };
 


### PR DESCRIPTION
Forgot about this fix that I made a while back.

This fixes the `TypeError: 'undefined' is not a function (evaluating 'this.emit('error', error)')` error found in the gist that I posted on https://github.com/n1k0/casperjs/pull/604#issuecomment-23520287
