### PR TITLE
Syntax fix and link addition for module writing doc

### DIFF
--- a/docs/writing_modules.rst
+++ b/docs/writing_modules.rst
@@ -36,7 +36,9 @@ From your root casper script::
     Like PhantomJS, CasperJS allows using nodejs modules installed through npm_.
    
 As an example, let's install the underscore_ library:
+
 .. _npm: https://npmjs.org/
+.. _underscore: http://underscorejs.org/
 
 .. code-block:: text
 


### PR DESCRIPTION
It looks like there was a missing newline for the reference syntax to be parsed correctly. Underscore.js also had no reference so one was added.
