### PR TITLE
Update frame code

### DIFF
--- a/bin/casperjs
+++ b/bin/casperjs
@@ -89,7 +89,8 @@ ENGINE_NATIVE_ARGS = []
 ENGINE_EXECUTABLE = ''
 
 CASPER_ARGS = []
-CASPER_PATH = os.path.abspath(os.path.join(os.path.dirname(resolve(__file__)), '..'))
+CASPER_PATH = os.path.abspath(os.path.join(os.path.dirname(resolve(__file__)),
+                                           '..'))
 SYS_ARGS = sys.argv[1:]
 
 # retrieve the engine name
@@ -98,23 +99,30 @@ for arg in SYS_ARGS:
         ENGINE = arg[9:].lower()
         break
 
-if ENGINE in SUPPORTED_ENGINES:
-    ENGINE_NATIVE_ARGS = SUPPORTED_ENGINES[ENGINE]['native_args']
-    ENGINE_EXECUTABLE = os.environ.get(SUPPORTED_ENGINES[ENGINE]['env_varname'], SUPPORTED_ENGINES[ENGINE]['default_exec'])
-else:
+if not ENGINE in SUPPORTED_ENGINES:
     print('Bad engine name. Only phantomjs and slimerjs are supported')
     sys.exit(1)
 
+ENGINE_NATIVE_ARGS = SUPPORTED_ENGINES[ENGINE]['native_args']
+ENGINE_EXECUTABLE = os.environ.get(SUPPORTED_ENGINES[ENGINE]['env_varname'],
+                                   SUPPORTED_ENGINES[ENGINE]['default_exec'])
+
+def extract_arg_name(arg):
+    "parse out any option name"
+    try:
+        return arg.split('=', 1)[0].replace('--', '', 1)
+    except IndexError:
+        return arg
 
 for arg in SYS_ARGS:
+    arg_name = extract_arg_name(arg)
     found = False
     for native in ENGINE_NATIVE_ARGS:
-        if arg == '--%s' % native:
+        if arg_name == native:
             ENGINE_ARGS.append(arg)
             found = True
-    if not found:
-        if arg.startswith('--engine=') == False:
-            CASPER_ARGS.append(arg)
+    if not found and arg_name != 'engine':
+        CASPER_ARGS.append(arg)
 
 CASPER_COMMAND = ENGINE_EXECUTABLE.split(' ')
 CASPER_COMMAND.extend(ENGINE_ARGS)

--- a/docs/events-filters.rst
+++ b/docs/events-filters.rst
@@ -126,16 +126,12 @@ Emitted when the ``Casper.exit()`` method has been called.
 
 Emitted when a form is filled using the ``Casper.fill()`` method.
 
-.. index:: forward
-
 ``forward``
 ~~~~~~~~~~~
 
 **Arguments:** ``None``
 
 Emitted when the embedded browser is asked to go forward a step in its history.
-
-.. index:: frame.changed
 
 ``frame.changed``
 ~~~~~~~~~~~~~~~~~

--- a/docs/events-filters.rst
+++ b/docs/events-filters.rst
@@ -126,12 +126,23 @@ Emitted when the ``Casper.exit()`` method has been called.
 
 Emitted when a form is filled using the ``Casper.fill()`` method.
 
+.. index:: forward
+
 ``forward``
 ~~~~~~~~~~~
 
 **Arguments:** ``None``
 
 Emitted when the embedded browser is asked to go forward a step in its history.
+
+.. index:: frame.changed
+
+``frame.changed``
+~~~~~~~~~~~~~~~~~
+
+**Arguments:** ``name``
+
+Emitted when the current frame is changed with ``Casper.switchToFrame()``.
 
 .. index:: auth
 

--- a/docs/modules/casper.rst
+++ b/docs/modules/casper.rst
@@ -1582,6 +1582,47 @@ Returns the status of current Casper instance::
 
     casper.run();
 
+
+``switchToFrame()``
+-------------------------------------------------------------------------------
+
+**Signature:** ``switchToFrame(String|Number frameInfo)``
+
+.. versionadded:: 1.2
+
+Switches the main page to the frame having the name or frame index number matching the passed argument. Inject local scripts, remote scripts and client utils into this frame. 
+
+
+``switchToFocusedFrame()``
+-------------------------------------------------------------------------------
+
+**Signature:** ``switchToFocusedFrame()``
+
+.. versionadded:: 1.2
+
+Switches the main page to the frame having the focus. Inject local scripts, remote scripts and client utils into this frame. 
+
+
+``switchToMainFrame()``
+-------------------------------------------------------------------------------
+
+**Signature:** ``switchToMainFrame()``
+
+.. versionadded:: 1.2
+
+Switch the main page to the parent frame of the currently active one.
+
+
+``switchToParentFrame()``
+-------------------------------------------------------------------------------
+
+**Signature:** ``switchToParentFrame()``
+
+.. versionadded:: 1.2
+
+Switch the main page to the main frame.
+
+
 .. index:: Step stack, Asynchronicity
 
 ``then()``

--- a/modules/casper.js
+++ b/modules/casper.js
@@ -2249,18 +2249,15 @@ Casper.prototype.waitWhileVisible = function waitWhileVisible(selector, then, on
  * Makes the provided frame page as the currently active one. Note that the
  * active page will NOT be reverted when finished.
  *
- * @param  String|Number    frameInfo  Target frame name or number
- * @param  Function  then       Next step function
+ * @param  String|Number frameInfo  Target frame name or number
  * @return Casper
  */
 Casper.prototype.switchToFrame = function switchToFrame(frameInfo) {
     "use strict";
-    if (utils.isNumber(frameInfo)) {
-        if (frameInfo > this.page.framesCount - 1) {
-            throw new CasperError(f('Frame number "%d" is out of bounds.', frameInfo));
-        }
-    } else if (this.page.framesName.indexOf(frameInfo) === -1) {
+    if (utils.isString(frameInfo) && this.page.childFramesName().indexOf(frameInfo) === -1) {
         throw new CasperError(f('No frame named "%s" was found.', frameInfo));
+    } else if (utils.isNumber(frameInfo) && frameInfo > this.page.childFramesCount() - 1) {
+        throw new CasperError(f('Frame number "%d" is out of bounds.', frameInfo));
     }
     // make the frame page the currently active one
     this.page.switchToFrame(frameInfo);
@@ -2273,11 +2270,57 @@ Casper.prototype.switchToFrame = function switchToFrame(frameInfo) {
     return this;
 };
 /**
+ * Makes the frame page which has focus the currently active one. Note that the
+ * active page will NOT be reverted when finished.
+ *
+ * @param  String|Number frameInfo  Target frame name or number
+ * @return Casper
+ */
+Casper.prototype.switchToFocusedFrame = function switchToFocusedFrame() {
+    "use strict";
+    this.page.switchToFocusedFrame();
+    // inject local, remote and utils client scripts into frame
+    this.injectClientScripts();
+    this.includeRemoteScripts();
+    this.injectClientUtils();
+    this.emit('frame.changed', this.page.frameName);
+
+    return this;
+}
+/**
+ * Makes the main frame the currently active one. Note that the
+ * active page will NOT be reverted when finished.
+ *
+ * @param  String|Number frameInfo  Target frame name or number
+ * @return Casper
+ */
+Casper.prototype.switchToMainFrame = function switchToMainFrame() {
+    "use strict";
+    this.page.switchToMainFrame();
+    this.emit('frame.changed', this.page.frameName);
+
+    return this;
+}
+/**
+ * Makes parent frame of current one the currently active one. Note that the
+ * active page will NOT be reverted when finished.
+ *
+ * @param  String|Number frameInfo  Target frame name or number
+ * @return Casper
+ */
+Casper.prototype.switchToParentFrame = function switchToParentFrame() {
+    "use strict";
+    this.page.switchToParentFrame();
+    this.emit('frame.changed', this.page.frameName);
+
+    return this;
+}
+/**
  * Makes the provided frame page as the currently active one. Note that the
  * active page will be reverted when finished.
  *
- * @param  String|Number    frameInfo  Target frame name or number
- * @param  Function  then       Next step function
+ * @param  String|Number frameInfo  Target frame name or number
+ * @param  Function      then       Next step function
  * @return Casper
  */
 Casper.prototype.withFrame = function withFrame(frameInfo, then) {

--- a/tests/suites/casper/frames.js
+++ b/tests/suites/casper/frames.js
@@ -1,6 +1,6 @@
 /*global casper, __utils__*/
 /*jshint strict:false*/
-casper.test.begin('handling frames', 20, function(test) {
+casper.test.begin('handling frames', 25, function(test) {
     casper.start('tests/site/frames.html');
 
     casper.withFrame('frame1', function() {
@@ -40,18 +40,23 @@ casper.test.begin('handling frames', 20, function(test) {
 
 
     casper.then(function() {
-      casper.page.switchToMainFrame();
-      casper.on('frame.changed', function (name) {
-        test.assertEquals(name, 'frame1');
-      });
-      casper.switchToFrame("frame1");
-      test.assertTitle('CasperJS frame 1');
-      casper.then(function() {
-        // Same frame in next step
-        test.assertTitle('CasperJS frame 1');
+        var expected = ['frame1', '', 'frame2', ''];
         casper.page.switchToMainFrame();
-        test.assertTitle("CasperJS test frames");
-      });
+        casper.on('frame.changed', function (name) {
+          test.assertEquals(name, expected.shift());
+        });
+        casper.switchToFrame("frame1");
+        test.assertTitle('CasperJS frame 1');
+        casper.then(function() {
+            // Same frame in next step
+            test.assertTitle('CasperJS frame 1');
+            casper.switchToParentFrame();
+            test.assertTitle("CasperJS test frames");
+            casper.switchToFrame("frame2");
+            test.assertTitle('CasperJS frame 3');
+            casper.switchToMainFrame();
+            test.assertTitle("CasperJS test frames");
+        });
     });
 
     casper.run(function() {

--- a/tests/suites/casper/frames.js
+++ b/tests/suites/casper/frames.js
@@ -1,6 +1,6 @@
 /*global casper, __utils__*/
 /*jshint strict:false*/
-casper.test.begin('handling frames', 16, function(test) {
+casper.test.begin('handling frames', 20, function(test) {
     casper.start('tests/site/frames.html');
 
     casper.withFrame('frame1', function() {
@@ -36,6 +36,22 @@ casper.test.begin('handling frames', 16, function(test) {
 
     casper.withFrame(1, function() {
         test.assertTitle('CasperJS frame 3');
+    });
+
+
+    casper.then(function() {
+      casper.page.switchToMainFrame();
+      casper.on('frame.changed', function (name) {
+        test.assertEquals(name, 'frame1');
+      });
+      casper.switchToFrame("frame1");
+      test.assertTitle('CasperJS frame 1');
+      casper.then(function() {
+        // Same frame in next step
+        test.assertTitle('CasperJS frame 1');
+        casper.page.switchToMainFrame();
+        test.assertTitle("CasperJS test frames");
+      });
     });
 
     casper.run(function() {


### PR DESCRIPTION
Some update of the frame code:
- methods `childFramesCount`, `childFramesName` and `switchToChildFrame` are deprecated. Replace them with their new synonyms;
- I need to play with the content of an iframe for more than one step, so I exposed the `switchToFrame` method;
- also, I need my clients scripts into the frame, so I injected them;
- I like events, so I added a `frame.changed` event.To be consistent, maybe should I also encapsulate `switchToParentFrame` and `switchToMainFrame`, to also emit this event ?
