### PR TITLE
Add improved RPM package build script.

### DIFF
--- a/rpm/build
+++ b/rpm/build
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# A little helper script to build the RPM.
+
+if [ ! -f "../package.json" ]; then
+    echo "Execute rpm build script in rpm directory"
+    exit 1
+fi
+
+name="casperjs"
+name=${name%.spec}
+topdir=$(mktemp -d)
+# Get version from package.json
+version=$(grep '"version"' ../package.json | sed 's/.*"\(.*\)": "\(.*\)".*/\2/' | sed 's/[-]//')
+builddir=${TMPDIR:-/tmp}/${name}-${version}
+sourcedir="${topdir}/SOURCES"
+buildroot="${topdir}/BUILD/${name}-${version}-root"
+
+mkdir -p ${topdir}/{RPMS,SRPMS,SOURCES,BUILD}
+mkdir -p ${buildroot} ${builddir}
+
+echo "=> Copying sources..."
+( cd .. && tar cf - ./[A-Z]* ./package.json ./bin ./samples ./tests ./modules | tar xf - -C ${builddir} )
+
+echo "=> Creating source tarball under ${sourcedir}..."
+( cd ${builddir}/.. && tar zcf ${sourcedir}/${name}-${version}.tar.gz ${name}-${version} )
+
+echo "=> Building RPM..."
+rpm=$(rpmbuild --define "_topdir ${topdir}" --define "_version ${version}" --buildroot ${buildroot} --clean -bb ${name}.spec | awk '/\/RPMS\// { print $2; }')
+
+if [ $? -ne 0 ]; then
+    echo "Failed to build RPM package."
+    exit 1
+fi
+
+echo ${rpm}
+cp ${rpm} ${TMPDIR:-/tmp}/
+rm -fr ${topdir}
+
+echo "RPM package build finished."
+echo ${TMPDIR:-/tmp}/${rpm##*/}

--- a/rpm/casperjs.spec
+++ b/rpm/casperjs.spec
@@ -1,0 +1,82 @@
+%define name    casperjs
+%if "%{_version}"
+%define version %{_version}
+%else
+%define version 1.0
+%endif
+%define release 1
+%define prefix  /usr
+
+%define mybuilddir %{_builddir}/%{name}-%{version}-root
+
+Summary:        open source navigation scripting & testing utility written in Javascript
+Name:           %{name}
+Version:        %{version}
+License:        BSD
+Release:        %{release}
+Packager:       Jan Schaumann <jschauma@etsy.com>
+Group:          Utilities/Misc
+Source:         %{name}-%{version}.tar.gz
+BuildRoot:      /tmp/%{name}-%{version}-root
+
+Requires:       phantomjs
+
+%description
+CasperJS is an open source navigation scripting & testing utility written
+in Javascript and based on PhantomJS.  It eases the process of defining a
+full navigation scenario and provides useful high-level functions, methods
+& syntactic sugar for doing common tasks
+
+%prep
+%setup -q
+
+%install
+mkdir -p %{mybuilddir}%{prefix}/bin
+mkdir -p %{mybuilddir}%{prefix}/share/%{name}/bin
+mkdir -p %{mybuilddir}%{prefix}/share/%{name}/modules
+mkdir -p %{mybuilddir}%{prefix}/share/%{name}/samples
+mkdir -p %{mybuilddir}%{prefix}/share/%{name}/tests
+
+cp bin/%{name} %{mybuilddir}%{prefix}/share/%{name}/bin/
+ln -s %{prefix}/share/%{name}/bin/%{name} %{mybuilddir}%{prefix}/bin/%{name}
+cp bin/bootstrap.js  %{mybuilddir}%{prefix}/share/%{name}/bin/
+# Yes, this tool needs this file in the 'bin' directory.
+cp bin/usage.txt %{mybuilddir}%{prefix}/share/%{name}/bin/
+cp CHANGELOG.md %{mybuilddir}%{prefix}/share/%{name}/
+cp CONTRIBUTING.md %{mybuilddir}%{prefix}/share/%{name}/
+cp CONTRIBUTORS.md %{mybuilddir}%{prefix}/share/%{name}/
+cp LICENSE.md %{mybuilddir}%{prefix}/share/%{name}/
+cp README.md %{mybuilddir}%{prefix}/share/%{name}/
+cp package.json %{mybuilddir}%{prefix}/share/%{name}/
+cp -R modules/* %{mybuilddir}%{prefix}/share/%{name}/modules/
+cp -R samples/* %{mybuilddir}%{prefix}/share/%{name}/samples/
+cp -R tests/* %{mybuilddir}%{prefix}/share/%{name}/tests/
+
+%files
+%defattr(0444,root,root)
+%attr(0555,root,root)%{prefix}/bin/%{name}
+%attr(0555,root,root)%{prefix}/share/%{name}/bin/%{name}
+%attr(0555,root,root)%{prefix}/share/%{name}/bin/bootstrap.js
+%{prefix}/share/%{name}/bin/usage.txt
+%{prefix}/share/%{name}/CHANGELOG.md
+%{prefix}/share/%{name}/CONTRIBUTING.md
+%{prefix}/share/%{name}/CONTRIBUTORS.md
+%{prefix}/share/%{name}/LICENSE.md
+%{prefix}/share/%{name}/README.md
+%{prefix}/share/%{name}/package.json
+%{prefix}/share/%{name}/modules/*
+%{prefix}/share/%{name}/samples/*
+%{prefix}/share/%{name}/tests/*
+
+%changelog
+* Fri Nov 15 2013 Yasuo Ohgaki <yohgaki@ohgaki.net>
+- update spec for master and other branches
+
+* Mon Dec 24 2012 Nicolas Perriault <nicolas@perriault.net>
+- removed 'injector.js' module
+
+* Mon Dec 10 2012 Jan Schaumann <jschauma@etsy.com>
+- include 'tests'
+
+* Mon Nov 26 2012 Jan Schaumann <jschauma@etsy.com>
+- first rpm version


### PR DESCRIPTION
Hi! 

This is a new RPM package build script.
It detects version from `package.json`.
The files that are installed are specified as wildcard, so you don't have to bother with RPM spec file when you add/remove/rename files.

Usage:

```
cd rpm
./build
```

then RPM package is created under `/tmp`
