### PR TITLE
refs #717 - fixed typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ First [install CasperJS](http://docs.casperjs.org/en/latest/installation.html), 
 Sample test to see if some dropdown can be opened:
 
 ```javascript
-casper.test.begin('a twitter bootsrap dropdown can be opened', 2, function(test) {
+casper.test.begin('a twitter bootstrap dropdown can be opened', 2, function(test) {
     casper.start('http://twitter.github.com/bootstrap/javascript.html#dropdowns', function() {
         test.assertExists('#navbar-example');
         this.click('#dropdowns .nav-pills .dropdown:last-of-type a.dropdown-toggle');


### PR DESCRIPTION
correct misspelled 'bootsrap' to 'bootstrap' on line 48 of the README.md

Fix #717
