### PR TITLE
Prevent overriding of preconfigured casper instance in a test environment

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -48,6 +48,13 @@ var defaultUserAgent = phantom.defaultPageSettings.userAgent
 
 exports.create = function create(options) {
     "use strict";
+    // This is a bit of a hack to check if one is trying to override the preconfigured
+    // casper instance from within a test environment.
+    if (phantom.casperTest && window.casper) {
+        console.error("Fatal: you can't override the preconfigured casper instance in a test environment.");
+        console.error("Docs: http://docs.casperjs.org/en/latest/testing.html#test-command-args-and-options");
+        phantom.exit(1);
+    }
     return new Casper(options);
 };
 

--- a/tests/clitests/runtests.py
+++ b/tests/clitests/runtests.py
@@ -304,6 +304,13 @@ class TestCommandOutputTest(CasperExecTestBase):
         ], failing=True)
 
     @timeout(20)
+    def test_casper_test_instance_overriding(self):
+        script_path = os.path.join(TEST_ROOT, 'tester', 'casper-instance-override.js')
+        self.assertCommandOutputContains('test ' + script_path, [
+            "Fatal: you can't override the preconfigured casper instance",
+        ], failing=True)
+
+    @timeout(20)
     def test_dubious_test(self):
         script_path = os.path.join(TEST_ROOT, 'tester', 'dubious.js')
         self.assertCommandOutputContains('test ' + script_path, [

--- a/tests/clitests/tester/casper-instance-override.js
+++ b/tests/clitests/tester/casper-instance-override.js
@@ -1,0 +1,9 @@
+// this should never happen
+// http://docs.casperjs.org/en/latest/testing.html#test-command-args-and-options
+var casper = require("casper").create();
+
+casper.test.begin("foo", function(test) {
+  "use strict";
+  test.assert(true);
+  test.done();
+});


### PR DESCRIPTION
This was a hard decision to make, but too many people just don't [read the docs](http://docs.casperjs.org/en/latest/testing.html#test-command-args-and-options) and create new casper instance(s) in a test env, overriding the preconfigured one, therefore creating cumbersome, hard to understand situations.

Hopefully this change will inform users right from the place they read docs the most, fatal error messages. So as of now you'll get this fatal error when creating a new casper instance in your test script:

```
Fatal: you can't override the preconfigured casper instance in a test environment.
```

**Reminder: when using the `casperjs test` subcommand, you _must not_ create a new `casper` instance, just use the provided one. You may argue it's always been a bad design decision, but that's the way it is. We'll change this for 2.0.**
