### PR TITLE
Allow usage of require.paths

### DIFF
--- a/bin/bootstrap.js
+++ b/bin/bootstrap.js
@@ -76,6 +76,7 @@ CasperError.prototype = Object.getPrototypeOf(new Error());
 
 // casperjs env initialization
 (function(global, phantom){
+    /*jshint maxstatements:99*/
     "use strict";
     // phantom args
     // NOTE: we can't use require('system').args here for some very obscure reason


### PR DESCRIPTION
Maintains support for versions of PhantomJS that don't support require.paths

ref #612
