### PR TITLE
Higher priority for working dir `localModulePath`

### DIFF
--- a/bin/bootstrap.js
+++ b/bin/bootstrap.js
@@ -250,7 +250,7 @@ CasperError.prototype = Object.getPrototypeOf(new Error());
             return resolveFile(path, fs.pathJoin(getCurrentScriptRoot(), 'node_modules'));
         }
         function localModulePath(path) {
-            return resolveFile(path, phantom.casperScriptBaseDir || fs.workingDirectory);
+            return resolveFile(path, fs.workingDirectory || phantom.casperScriptBaseDir);
         }
         var patchedRequire = function patchedRequire(path) {
             try {


### PR DESCRIPTION
Make `fs.workingDirectory` priority higher, otherwise `localModulePath` would mean `casperScriptBaseDirPath`
