### PR TITLE
Add missing fields to resourceError description

### DIFF
--- a/docs/events-filters.rst
+++ b/docs/events-filters.rst
@@ -356,8 +356,10 @@ Emitted when any remote console logging call has been performed.
 
 Emitted when any requested resource fails to load properly. The received ``resourceError`` object has the following properties:
 
-- ``errorCode``: HTTP status code received
+- ``errorCode``: error code
+- ``errorString``: error description
 - ``url``: resource url
+- ``id``: resource id
 
 ``resource.received``
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Also, `errorCode` doesn't always represent the HTTP status.

For example, I sometimes get this:

``` json
{
    "errorCode": 5,
    "errorString": "Operation canceled",
    "id": 70,
    "url": "http://api.example.com"
}
```
