### PR TITLE
Feature Request: PhantomJS Thread Support

### DIFF
--- a/samples/thread-crawler.js
+++ b/samples/thread-crawler.js
@@ -1,0 +1,175 @@
+/*jshint strict:false*/
+/*global CasperError, console, phantom, require*/
+
+var Casper = require('casper').Casper;
+var Pool = require('generic-pool').Pool;
+var async = require('async');
+var _ = require('lodash');
+var UserAgents = require('./useragents.json');
+
+// The base links array
+var links = [
+    "http://en.wikipedia.org"
+];
+
+var maxThreads = 3;
+var maxThreadAge = 3;
+var trimHashes = true;
+var stayInRange = true;
+var skipDupes = true;
+
+var start = Date.now();
+var completed = 0;
+
+var tasks = links.map(function (link, index) {
+    return {
+        uri: link
+    };
+});
+
+var RX = {
+    isHTML: /text\/html/,
+    getNum: /\d+/
+};
+var pool = Pool({
+    name     : 'casper',
+    create   : function(callback) {
+        var casper = new Casper({
+            verbose: true
+        });
+        casper.crawledPages = 0;
+        callback(null, casper);
+    },
+    destroy  : function (casper) {
+        casper.exit();
+    },
+    max      : maxThreads,
+    idleTimeoutMillis : 30000
+});
+
+var q = async.queue(function (task, asyncCheckIn) {
+    pool.acquire(function(err, casper) {
+        casper.crawledPages++;
+        runTask(task, casper, function () {
+            if (casper.crawledPages < maxThreadAge) {
+                pool.release(casper);
+            } else {
+                pool.destroy(casper);
+            }
+            asyncCheckIn();
+        });
+    });
+}, maxThreads);
+q.push(tasks);
+
+function runTask (task, casper, callback) {
+    var info = {
+        uri: task.uri,
+        parent: task.parent
+    };
+    var taskStart = Date.now();
+    casper.start();
+    casper.userAgent(UserAgents['Google Chrome 32 (Mac)']);
+    // casper.viewport(1024, 768);
+    casper.open(task.uri, {
+        method: 'get',
+        headers: {}
+    });
+    casper.then(function (response) {
+        // Specific Logic for tapping Varnish cache info
+        var hits = response.headers.get('X-Cache-Hits') || 0;
+        var cacheControl = response.headers.get('Cache-Control');
+        var maxAge = cacheControl ? RX.getNum.exec(cacheControl) : '';
+        var contentType = response.headers.get('Content-Type');
+        maxAge = maxAge ? maxAge[0] : '';
+        info.status = response.status;
+        info.cache = response.headers.get('X-Cache');
+        info.hits = hits;
+        info.expires = prettyTime(maxAge);
+        info.contentType = contentType;
+    });
+    casper.then(function () {
+        if (info.status === 200 && RX.isHTML.test(info.contentType)) {
+            var newLinks = gatherLinks(this, task);
+            newLinks.forEach(function (uri, index) {
+                q.push({
+                    parent: task.uri,
+                    uri: uri
+                });
+            });
+            info.tasksAdded = newLinks.length;
+        }
+    });
+    casper.then(function () {
+        completed++;
+        info.tasksRemaining = q.length();
+        info.tasksCompleted = completed;
+        info.timeTask = prettyTime((Date.now() - taskStart) / 1000);
+        info.timeSoFar = prettyTime((Date.now() - start) / 1000);
+        this.echo(JSON.stringify(info, null, '\t'));
+    });
+    casper.run(callback);
+}
+
+function prettyTime (num) {
+    if (num < 0) return '0.' + (~~(num * 1000)) + 's';
+    if (num < 60) return (~~num) + 's';
+    if (num < 3600) return (~~(num / 60)) + 'm,' + (~~(num % 60)) + 's';
+    return (~~(num / 3600)) + 'h,' + (~~((num % 3600) / 60)) + 'm';
+}
+
+// Get the links, and add them to the links array
+// (It could be done all in one step, but it is intentionally splitted)
+function gatherLinks (casper, task) {
+    var found;
+    try {
+        found = casper.evaluate(searchLinks) || [];
+    } catch (e) {
+        return 0;
+    }
+    if (trimHashes) {
+        found = found.map(trimHash);
+    }
+    if (stayInRange) {
+        found = found.filter(inRange);
+    }
+    if (skipDupes) {
+        found = _.difference(_.unique(found), links);
+    }
+    return found;
+}
+
+// Fetch all <a> elements from the page and return
+// the ones which contains a href starting with 'http://'
+function searchLinks() {
+    return Array.prototype.map.call(
+        document.querySelectorAll("a"),
+        function(a) {
+            return a.href;
+        }
+    );
+}
+
+// Just opens the page and prints the title
+function start(link) {
+    this.start(link, function() {
+        this.echo('Page title: ' + this.getTitle());
+    });
+}
+
+// Checks if the URL is on one of our base links
+function inRange (url) {
+    for (var i = 0, l = links.length; i < l; i++) {
+        if (url.substr(0, links[i].length) === links[i]) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Removes hash's from URL's http://example.com/#faq-num-2
+function trimHash (uri) {
+    var indexOfHash = uri.indexOf('#');
+    return (indexOfHash !== -1) ? uri.substring(0, indexOfHash) : uri;
+}
+

--- a/samples/useragents.json
+++ b/samples/useragents.json
@@ -1,0 +1,30 @@
+{
+	"iOS 5.1 iPhone":
+	"Mozilla/5.0 (iPhone; CPU iPhone OS 5_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9B179 Safari/7534.48.3",
+	"iOS 5.1 iPod Touch":
+	"Mozilla/5.0 (iPod; CPU iPhone OS 5_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9B176 Safari/7534.48.3",
+	"iOS 5.1 iPad":
+	"Mozilla/5.0 (iPad; CPU OS 5_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9B176 Safari/7534.48.3",
+	"Safari 6.0 (Mac)":
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_4) AppleWebKit/536.25 (KHTML, like Gecko) Version/6.0 Safari/536.25",
+	"Safari 5.1.7 (Windows)":
+	"Mozilla/5.0 (Windows; Windows NT 6.1) AppleWebKit/534.57.2 (KHTML, like Gecko) Version/5.1.7 Safari/534.57.2",
+	"Internet Explorer 7":
+	"Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)",
+	"Internet Explorer 8":
+	"Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0)",
+	"Internet Explorer 9":
+	"Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)",
+	"Google Chrome 32 (Mac)":
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.77 Safari/537.36",
+	"Google Chrome 19 (Windows)":
+	"Mozilla/5.0 (Windows; Windows NT 6.1) AppleWebKit/536.5 (KHTML, like Gecko) Chrome/19.0.1084.46 Safari/536.5",
+	"Filefox 11.0 (Mac)":
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:11.0) Gecko/20100101 Firefox/11.0",
+	"Firefox 11.0 (Windows)":
+	"Mozilla/5.0 (Windows NT 6.1; rv:11.0) Gecko/20100101 Firefox/11.0",
+	"Opera 11.62 (Mac)":
+	"Opera/9.80 (Macintosh; Intel Mac OS X 10.7.4; U; en) Presto/2.10.229 Version/11.62",
+	"Opera 11.62 (Windows)":
+	"Opera/9.80 (Windows NT 6.1; U; en) Presto/2.10.229 Version/11.62"
+}


### PR DESCRIPTION
It's a known issue that CasperJS does not support threads, but I'd really like to see a little more thread support.  In particular, I'd like to be able to restart a PhantomJS thread.

If I don't include the thread killing logic on lines 54-58, then CasperJS crashes repeating the error `select: Invalid argument` after 500MB of memory or so.  If I do include the logic, then CasperJS will crash as soon as I attempt to kill a thread.  My other option here, is to manage Phantom pooling and threads through node, but so far I've difficulty getting the node/phantom layer to communicate properly.

Note: My example uses several npm modules.  These could easily be replaced by a few plain JS functions, but they keep it easier to read.
https://npmjs.org/package/generic-pool
https://npmjs.org/package/async
https://npmjs.org/package/lodash
