### PR TITLE
Enable POSTing JSON objects with casper.open() 

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -1396,7 +1396,11 @@ Casper.prototype.open = function open(location, settings) {
     // http data
     if (settings.data) {
         if (utils.isObject(settings.data)) { // query object
-            settings.data = qs.encode(settings.data);
+            if (settings.headers && settings.headers["Content-Type"] === "application/json") {
+                settings.data = JSON.stringify(settings.data); // convert object to JSON notation
+            } else {
+                settings.data = qs.encode(settings.data); // escapes all characters except alphabetic, decimal digits and ,-_.!~*'()
+            }
         } else if (!utils.isString(settings.data)) {
             throw new CasperError("open(): invalid request settings data value: " + settings.data);
         }

--- a/tests/suites/casper/open.js
+++ b/tests/suites/casper/open.js
@@ -99,6 +99,37 @@ casper.test.begin('open() POST casing tests', 2, {
     }
 });
 
+casper.test.begin('open() POST json object', 2, {
+    setUp: setUp,
+    tearDown: tearDown,
+    test: function(test) {
+        casper.open('tests/site/index.html', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            data:   {
+                plop: 42,
+                chuck: 'norris',
+                john: {'Doe': 'is here'}
+            }
+        }).then(function() {
+            test.pass("Casper.open() can POST a JSON object");
+            test.assertEquals(usedSettings, {
+                method: "POST",
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                data: '{"plop":42,"chuck":"norris","john":{"Doe":"is here"}}'
+            }, "Casper.open() used the expected POST settings");
+        });
+
+        casper.run(function() {
+            test.done();
+        });
+    }
+});
+
 casper.test.begin('open() PUT tests', 2, {
     setUp: setUp,
     tearDown: tearDown,


### PR DESCRIPTION
Use `JSON.stringify` for encoding the request body when `Content-Type` is `application/json`.
