### PR TITLE
In the installation page, add --engine=slimerjs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -17,7 +17,7 @@ Prerequisites
 
 .. versionadded:: 1.1
 
-- **Experimental:** as of 1.1-beta1, SlimerJS_ 0.8 or greater to run your tests against Gecko (Firefox) instead of Webkit. To see PhantomJS API compatibility of SlimerJS, please `refer to this page <https://github.com/laurentj/slimerjs/blob/master/API_COMPAT.md>`_.
+- **Experimental:** as of 1.1-beta1, SlimerJS_ 0.8 or greater to run your tests against Gecko (Firefox) instead of Webkit (just add `--engine=slimerjs` to your command line options). To see PhantomJS API compatibility of SlimerJS, please `refer to this page <https://github.com/laurentj/slimerjs/blob/master/API_COMPAT.md>`_.
 
 .. index:: Homebrew
 


### PR DESCRIPTION
I couldn't find a place to find this info, except in SlimerJS docs.
Maybe a page dedicated to using SlimerJS with CasperJS would be nice?
I could try an humble start in this direction.
