### PR TITLE
Add style.display check for inline-block when determining element visibility

### DIFF
--- a/modules/clientutils.js
+++ b/modules/clientutils.js
@@ -164,7 +164,7 @@
             if (hidden) {
                 return false;
             }
-            if (style.display === "inline") {
+            if (style.display === "inline" || style.display === "inline-block") {
                 return true;
             }
             return elem.clientHeight > 0 && elem.clientWidth > 0;

--- a/tests/suites/clientutils.js
+++ b/tests/suites/clientutils.js
@@ -201,3 +201,23 @@ casper.test.begin('ClientUtils.getElementsInfo() second element tests', 10, func
         'ClientUtils.getElementsInfo() retrieves second element whole tag contents');
     test.done();
 });
+
+casper.test.begin('ClientUtils.getElementInfo() visibility tests', 4, function(test) {
+    casper.page.content = '<a href="plop" class="plip plup" style="display: inline"><i>paf</i></a>';
+    var info = casper.getElementInfo('a.plip');
+    test.assert(info.visible, 'ClientUtils.getElementInfo() retrieves element visibility with display inline');
+
+    casper.page.content = '<a href="plop" class="plip plup" style="display: inline-block"><i>paf</i></a>';
+    info = casper.getElementInfo('a.plip');
+    test.assert(info.visible, 'ClientUtils.getElementInfo() retrieves element visibility with display inline-block');
+
+    casper.page.content = '<a href="plop" class="plip plup" style="visibility: hidden"><i>paf</i></a>';
+    info = casper.getElementInfo('a.plip');
+    test.assertNot(info.visible, 'ClientUtils.getElementInfo() retrieves element visibility with visibility hidden');
+
+    casper.page.content = '<a href="plop" class="plip plup" style="display: none"><i>paf</i></a>';
+    info = casper.getElementInfo('a.plip');
+    test.assertNot(info.visible, 'ClientUtils.getElementInfo() retrieves element visibility with display none');
+
+    test.done();
+});


### PR DESCRIPTION
When checking for visibility, style.display is checked to match “inline”.  Added a check for “inline-block”.
