### PR TITLE
Use subprocess.call instead of os.exec to launch casperjs

### DIFF
--- a/bin/casperjs
+++ b/bin/casperjs
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import subprocess
 
 def resolve(path):
     if os.path.islink(path):
@@ -133,8 +134,11 @@ CASPER_COMMAND.extend([
 ])
 CASPER_COMMAND.extend(CASPER_ARGS)
 
+retval = 0
 try:
-    os.execvp(CASPER_COMMAND[0], CASPER_COMMAND)
+    retval = subprocess.call(CASPER_COMMAND)
 except OSError as err:
     print('Fatal: %s; did you install %s?' % (err, ENGINE))
     sys.exit(1)
+
+sys.exit(retval)


### PR DESCRIPTION
Using os.exec on Windows causes the process to fork into the background--meaning that a command line environment running casperjs will not be able to read the return code or easily detect when the script has finished execution.

subprocess.call provides better cross-platform compatibility, and fixes the problem easily.
