### PR TITLE
Remove spurious fs calls

### DIFF
--- a/modules/tester.js
+++ b/modules/tester.js
@@ -1274,7 +1274,7 @@ Tester.prototype.findTestFiles = function findTestFiles(dir) {
         }
     });
     return entries.filter(function _filter(entry) {
-        return utils.isJsFile(fs.absolute(fs.pathJoin(dir, entry)));
+        return utils.isJsFile(entry);
     }).sort();
 };
 


### PR DESCRIPTION
`entry` already contains an absolute path. The path that is constructed is strange and unusual. This causes issues on Windows with TrifleJS (WIP).
