### PR TITLE
add json configuration option for tests

### DIFF
--- a/bin/bootstrap.js
+++ b/bin/bootstrap.js
@@ -76,7 +76,7 @@ CasperError.prototype = Object.getPrototypeOf(new Error());
 
 // casperjs env initialization
 (function(global, phantom){
-    /*jshint maxstatements:99*/
+    /*jshint maxstatements:99, maxcomplexity:15*/
     "use strict";
     // phantom args
     // NOTE: we can't use require('system').args here for some very obscure reason
@@ -375,8 +375,40 @@ CasperError.prototype = Object.getPrototypeOf(new Error());
 
     // casper cli args
     phantom.casperArgs = require('cli').parse(phantomArgs);
+    var getopts = phantom.casperArgs.get.bind(phantom.casperArgs);
+    var cliargs = phantom.casperArgs.raw.args;
 
-    if (true === phantom.casperArgs.get('cli')) {
+    if (getopts('cli')) {
+        var unaryarg = getopts(1);
+        if (require('utils').isFileExtOfType(unaryarg, 'json')) {
+            var config;
+            try {
+                config = require(unaryarg);
+            } catch (e) {
+                return __die('Unable to parse config file: ' + e.message);
+            }
+
+            if (getopts(0).match(/^(selftest|test)$/)) {
+                cliargs = [getopts(0)];
+            }
+
+            if (config.paths) {
+                cliargs = cliargs.concat([]
+                    .slice.call(config.paths)
+                    .map(function(x) {
+                        return fs.absolute(fs.pathJoin(fs.dirname(unaryarg), x));
+                    }));
+                delete config.paths;
+            }
+
+            Object.keys(config).forEach(function(key) {
+                if (config[key]) phantom.casperArgs.raw.options[key] = config[key].toString();
+            });
+
+            phantom.casperArgs.args = phantom.casperArgs.raw.args = [].slice.call(cliargs);
+            phantom.casperArgs.options = phantom.casperArgs.raw.options;
+        }
+        
         initCasperCli(phantom.casperArgs);
     }
 

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -190,6 +190,7 @@ exports.dump = dump;
  * @param  Boolean
  */
 function equals(v1, v2) {
+    /*jshint maxcomplexity:9*/
     "use strict";
     if (isFunction(v1)) {
         return v1.toString() === v2.toString();
@@ -468,6 +469,21 @@ function isJsFile(file) {
     return isString(ext, "string") && ['js', 'coffee'].indexOf(ext) !== -1;
 }
 exports.isJsFile = isJsFile;
+
+/**
+ * Checks if a file is of the given extension type.
+ *
+ * @param  String  file  Path to the file to test
+ * @param  String  type  extension to match for
+ * @return Boolean
+ */
+function isFileExtOfType(file, type) {
+    "use strict";
+    var ext = fileExt(file);
+    type = isString(type) ? [type] : type;
+    return isString(ext, "string") && type.indexOf(ext) !== -1;
+}
+exports.isFileExtOfType = isFileExtOfType;
 
 /**
  * Checks if the provided value is null

--- a/tests/clitests/configs/casper-instance-override.json
+++ b/tests/clitests/configs/casper-instance-override.json
@@ -1,0 +1,5 @@
+{
+    "paths": [
+        "../tester/casper-instance-override.js"
+    ]
+}

--- a/tests/clitests/configs/dubious.json
+++ b/tests/clitests/configs/dubious.json
@@ -1,0 +1,5 @@
+{
+    "paths": [
+        "../tester/dubious.js"
+    ]
+}

--- a/tests/clitests/configs/exit.json
+++ b/tests/clitests/configs/exit.json
@@ -1,0 +1,5 @@
+{
+    "paths": [
+        "../tester/exit.js"
+    ]
+}

--- a/tests/clitests/configs/failfast.json
+++ b/tests/clitests/configs/failfast.json
@@ -1,0 +1,6 @@
+{
+    "paths": [
+        "../fail-fast/standard"
+    ],
+    "fail-fast": true
+}

--- a/tests/clitests/configs/failing.json
+++ b/tests/clitests/configs/failing.json
@@ -1,0 +1,5 @@
+{
+    "paths": [
+        "../tester/failing.js"
+    ]
+}

--- a/tests/clitests/configs/fullsuite.json
+++ b/tests/clitests/configs/fullsuite.json
@@ -1,0 +1,7 @@
+{
+    "paths": [
+        "../tester/failing.js",
+        "../tester/passing.js",
+        "../tester/mytest.js"
+    ]
+}

--- a/tests/clitests/configs/manualabort.json
+++ b/tests/clitests/configs/manualabort.json
@@ -1,0 +1,6 @@
+{
+    "paths": [
+        "../fail-fast/manual-abort"
+    ],
+    "fail-fast": true
+}

--- a/tests/clitests/configs/passing.json
+++ b/tests/clitests/configs/passing.json
@@ -1,0 +1,5 @@
+{
+    "paths": [
+        "../tester/passing.js"
+    ]
+}

--- a/tests/clitests/configs/simple_test_script.json
+++ b/tests/clitests/configs/simple_test_script.json
@@ -1,0 +1,5 @@
+{
+    "paths": [
+        "../tester/mytest.js"
+    ]
+}

--- a/tests/clitests/configs/skipped.json
+++ b/tests/clitests/configs/skipped.json
@@ -1,0 +1,5 @@
+{
+    "paths": [
+        "../tester/skipped.js"
+    ]
+}

--- a/tests/clitests/configs/step_throws.json
+++ b/tests/clitests/configs/step_throws.json
@@ -1,0 +1,5 @@
+{
+    "paths": [
+        "../tester/step_throws.js"
+    ]
+}

--- a/tests/clitests/configs/waitFor_timeout.json
+++ b/tests/clitests/configs/waitFor_timeout.json
@@ -1,0 +1,5 @@
+{
+    "paths": [
+        "../tester/waitFor_timeout.js"
+    ]
+}

--- a/tests/clitests/configs/xunit-failing.json
+++ b/tests/clitests/configs/xunit-failing.json
@@ -1,0 +1,6 @@
+{
+    "paths": [
+        "../tester/failing.js"
+    ],
+    "xunit": "tests/clitests/__log.xml"
+}

--- a/tests/clitests/configs/xunit-passing.json
+++ b/tests/clitests/configs/xunit-passing.json
@@ -1,0 +1,6 @@
+{
+    "paths": [
+        "../tester/passing.js"
+    ],
+    "xunit": "tests/clitests/__log.xml"
+}

--- a/tests/clitests/runtests.py
+++ b/tests/clitests/runtests.py
@@ -239,6 +239,22 @@ class TestCommandOutputTest(CasperExecTestBase):
         ])
 
     @timeout(20)
+    def test_config_simple_test_script(self):
+        config_path = os.path.join(TEST_ROOT, 'configs', 'simple_test_script.json')
+        script_path = os.path.join(TEST_ROOT, 'tester', 'mytest.js')
+        self.assertCommandOutputContains('test ' + config_path, [
+            script_path,
+            'PASS ok1',
+            'PASS ok2',
+            'PASS ok3',
+            '3 tests executed',
+            '3 passed',
+            '0 failed',
+            '0 dubious',
+            '0 skipped',
+        ])
+
+    @timeout(20)
     def test_new_style_test(self):
         # using begin()
         script_path = os.path.join(TEST_ROOT, 'tester', 'passing.js')
@@ -254,10 +270,46 @@ class TestCommandOutputTest(CasperExecTestBase):
         ])
 
     @timeout(20)
+    def test_config_new_style_test(self):
+        # using begin()
+        config_path = os.path.join(TEST_ROOT, 'configs', 'passing.json')
+        script_path = os.path.join(TEST_ROOT, 'tester', 'passing.js')
+        self.assertCommandOutputContains('test ' + config_path, [
+            script_path,
+            '# true',
+            'PASS Subject is strictly true',
+            'PASS 1 test executed',
+            '1 passed',
+            '0 failed',
+            '0 dubious',
+            '0 skipped',
+        ])
+
+    @timeout(20)
     def test_new_failing_test(self):
         # using begin()
         script_path = os.path.join(TEST_ROOT, 'tester', 'failing.js')
         self.assertCommandOutputContains('test ' + script_path, [
+            script_path,
+            '# true',
+            'FAIL Subject is strictly true',
+            '#    type: assert',
+            '#    file: %s:3' % script_path,
+            '#    code: test.assert(false);',
+            '#    subject: false',
+            'FAIL 1 test executed',
+            '0 passed',
+            '1 failed',
+            '0 dubious',
+            '0 skipped',
+        ], failing=True)
+
+    @timeout(20)
+    def test_config_new_failing_test(self):
+        # using begin()
+        config_path = os.path.join(TEST_ROOT, 'configs', 'failing.json')
+        script_path = os.path.join(TEST_ROOT, 'tester', 'failing.js')
+        self.assertCommandOutputContains('test ' + config_path, [
             script_path,
             '# true',
             'FAIL Subject is strictly true',
@@ -291,10 +343,45 @@ class TestCommandOutputTest(CasperExecTestBase):
         ], failing=True)
 
     @timeout(20)
+    def test_config_step_throwing_test(self):
+        # using begin()
+        config_path = os.path.join(TEST_ROOT, 'configs', 'step_throws.json')
+        script_path = os.path.join(TEST_ROOT, 'tester', 'step_throws.js')
+        self.assertCommandOutputContains('test ' + config_path, [
+            script_path,
+            '# step throws',
+            'FAIL Error: oops!',
+            '#    type: uncaughtError',
+            '#    file: %s:5' % script_path,
+            '#    error: oops!',
+            'FAIL 1 test executed',
+            '0 passed',
+            '1 failed',
+            '0 dubious',
+            '0 skipped',
+        ], failing=True)
+
+    @timeout(20)
     def test_waitFor_timeout(self):
         # using begin()
         script_path = os.path.join(TEST_ROOT, 'tester', 'waitFor_timeout.js')
         self.assertCommandOutputContains('test ' + script_path, [
+            '"p.nonexistent" still did not exist in',
+            '"#encoded" did not have a text change in',
+            '"p[style]" never appeared in',
+            '/github\.com/ did not load in',
+            '/foobar/ did not pop up in',
+            '"Lorem ipsum" did not appear in the page in',
+            'return false',
+            'did not evaluate to something truthy in'
+        ], failing=True)
+
+    @timeout(20)
+    def test_config_waitFor_timeout(self):
+        # using begin()
+        config_path = os.path.join(TEST_ROOT, 'configs', 'waitFor_timeout.json')
+        script_path = os.path.join(TEST_ROOT, 'tester', 'waitFor_timeout.js')
+        self.assertCommandOutputContains('test ' + config_path, [
             '"p.nonexistent" still did not exist in',
             '"#encoded" did not have a text change in',
             '"p[style]" never appeared in',
@@ -313,9 +400,31 @@ class TestCommandOutputTest(CasperExecTestBase):
         ], failing=True)
 
     @timeout(20)
+    def test_config_casper_test_instance_overriding(self):
+        config_path = os.path.join(TEST_ROOT, 'configs', 'casper-instance-override.json')
+        script_path = os.path.join(TEST_ROOT, 'tester', 'casper-instance-override.js')
+        self.assertCommandOutputContains('test ' + config_path, [
+            "Fatal: you can't override the preconfigured casper instance",
+        ], failing=True)
+
+    @timeout(20)
     def test_dubious_test(self):
         script_path = os.path.join(TEST_ROOT, 'tester', 'dubious.js')
         self.assertCommandOutputContains('test ' + script_path, [
+            script_path,
+            'dubious test: 2 tests planned, 1 tests executed',
+            'FAIL 1 test executed',
+            '1 passed',
+            '1 failed',
+            '1 dubious',
+            '0 skipped',
+        ], failing=True)
+
+    @timeout(20)
+    def test_config_dubious_test(self):
+        config_path = os.path.join(TEST_ROOT, 'configs', 'dubious.json')
+        script_path = os.path.join(TEST_ROOT, 'tester', 'dubious.js')
+        self.assertCommandOutputContains('test ' + config_path, [
             script_path,
             'dubious test: 2 tests planned, 1 tests executed',
             'FAIL 1 test executed',
@@ -341,9 +450,39 @@ class TestCommandOutputTest(CasperExecTestBase):
         ])
 
     @timeout(20)
+    def test_config_exit_test(self):
+        config_path = os.path.join(TEST_ROOT, 'configs', 'exit.json')
+        script_path = os.path.join(TEST_ROOT, 'tester', 'exit.js')
+        self.assertCommandOutputContains('test ' + config_path, [
+            script_path,
+            '# sample',
+            'PASS Subject is strictly true',
+            'PASS 1 test executed',
+            '1 passed',
+            '0 failed',
+            '0 dubious',
+            '0 skipped.',
+            'exited'
+        ])
+
+    @timeout(20)
     def test_skipped_test(self):
         script_path = os.path.join(TEST_ROOT, 'tester', 'skipped.js')
         self.assertCommandOutputContains('test ' + script_path, [
+            script_path,
+            'SKIP 1 test skipped',
+            'PASS 1 test executed',
+            '1 passed',
+            '0 failed',
+            '0 dubious',
+            '1 skipped',
+        ])
+
+    @timeout(20)
+    def test_config_skipped_test(self):
+        config_path = os.path.join(TEST_ROOT, 'configs', 'skipped.json')
+        script_path = os.path.join(TEST_ROOT, 'tester', 'skipped.js')
+        self.assertCommandOutputContains('test ' + config_path, [
             script_path,
             'SKIP 1 test skipped',
             'PASS 1 test executed',
@@ -385,6 +524,37 @@ class TestCommandOutputTest(CasperExecTestBase):
             'assert: Subject is strictly true',
         ], failing=True)
 
+    @timeout(20)
+    def test_config_full_suite(self):
+        config_path = os.path.join(TEST_ROOT, 'configs', 'fullsuite.json')
+        folder_path = os.path.join(TEST_ROOT, 'tester')
+        failing_script = os.path.join(folder_path, 'failing.js')
+        passing_script = os.path.join(folder_path, 'passing.js')
+        mytest_script = os.path.join(folder_path, 'mytest.js')
+        self.assertCommandOutputContains('test ' + config_path, [
+            'Test file: %s' % failing_script,
+            '# true',
+            'FAIL Subject is strictly true',
+            '#    type: assert',
+            '#    file: %s:3' % failing_script,
+            '#    code: test.assert(false);',
+            '#    subject: false',
+            'Test file: %s' % mytest_script,
+            'PASS ok1',
+            'PASS ok2',
+            'PASS ok3',
+            'Test file: %s' % passing_script,
+            '# true',
+            'PASS Subject is strictly true',
+            'FAIL 5 tests executed',
+            '4 passed',
+            '1 failed',
+            '0 dubious',
+            '0 skipped',
+            'Details for the 1 failed test:',
+            'assert: Subject is strictly true',
+        ], failing=True)
+
     @timeout(60)
     def test_fail_fast(self):
         folder_path = os.path.join(TEST_ROOT, 'fail-fast', 'standard')
@@ -399,10 +569,34 @@ class TestCommandOutputTest(CasperExecTestBase):
             '0 skipped',
         ], failing=True)
 
+    @timeout(20)
+    def test_config_fail_fast(self):
+        config_path = os.path.join(TEST_ROOT, 'configs', 'failfast.json')
+        self.assertCommandOutputContains('test ' + config_path, [
+            '# test 1',
+            '# test 2',
+            '--fail-fast: aborted all remaining tests',
+            'FAIL 2 tests executed',
+            '1 passed',
+            '1 failed',
+            '0 dubious',
+            '0 skipped',
+        ], failing=True)
+
     @timeout(60)
     def test_manual_abort(self):
         folder_path = os.path.join(TEST_ROOT, 'fail-fast', 'manual-abort')
-        self.assertCommandOutputContains('test %s --fail-fast' % folder_path, [
+        self.assertCommandOutputContains('test %s' % folder_path, [
+            '# test abort()',
+            'PASS test 1',
+            'PASS test 5',
+            'this is my abort message',
+        ], failing=True)
+
+    @timeout(20)
+    def test_config_manual_abort(self):
+        config_path = os.path.join(TEST_ROOT, 'configs', 'manualabort.json')
+        self.assertCommandOutputContains('test ' + config_path, [
             '# test abort()',
             'PASS test 1',
             'PASS test 5',
@@ -429,9 +623,21 @@ class XUnitReportTest(CasperExecTestBase):
         self.runCommand(command, failing=False)
         self.assertTrue(os.path.exists(self.XUNIT_LOG))
 
+    def test_config_xunit_report_passing(self):
+        script_path = os.path.join(TEST_ROOT, 'configs', 'xunit-passing.json')
+        command = 'test %s' % (script_path)
+        self.runCommand(command, failing=False)
+        self.assertTrue(os.path.exists(self.XUNIT_LOG))
+
     def test_xunit_report_failing(self):
         script_path = os.path.join(TEST_ROOT, 'tester', 'failing.js')
         command = 'test %s --xunit=%s' % (script_path, self.XUNIT_LOG)
+        self.runCommand(command, failing=True)
+        self.assertTrue(os.path.exists(self.XUNIT_LOG))
+
+    def test_config_xunit_report_passing(self):
+        script_path = os.path.join(TEST_ROOT, 'configs', 'xunit-failing.json')
+        command = 'test %s' % (script_path)
         self.runCommand(command, failing=True)
         self.assertTrue(os.path.exists(self.XUNIT_LOG))
 


### PR DESCRIPTION
- provide a cli argument for config.json file
- parse arguments & options from config.json
- ensure config.json is valid and can be required
- ensure args & opts are stored back in phantom.casperArgs.raw
- fixes #745
- a config.json can look like:

``` json
    {
      "includes": [
        "inc1.js",
        "inc2.js"
      ],
      "log-level": "debug",
      "paths": [
        "test.js",
        "sub1"
      ],
      "post": [
        "post1.js",
        "post2.js"
      ],
      "pre": [
        "pre1.js",
        "pre2.js"
      ],
      "verbose": true,
      "xunit": "results.xml"
    }
```
- tests can be run using:
  `$ casperjs test ./config.json`
- note that, the config file is not a key word argument, since there are no additional arguments that
  you need to pass into the cli, if you provide a config.json.
