### PR TITLE
Use failure/success name attribute.

### DIFF
--- a/modules/xunit.js
+++ b/modules/xunit.js
@@ -108,7 +108,7 @@ XUnitExporter.prototype.getXML = function getXML() {
         // succesful test cases
         result.passes.forEach(function(success) {
             var testCase = utils.node('testcase', {
-                name: success.message || success.standard,
+                name: success.name || success.standard,
                 classname: generateClassName(success.file),
                 time: utils.ms2seconds(~~success.time)
             });
@@ -117,7 +117,7 @@ XUnitExporter.prototype.getXML = function getXML() {
         // failed test cases
         result.failures.forEach(function(failure) {
             var testCase = utils.node('testcase', {
-                name: failure.message || failure.standard,
+                name: failure.name || failure.standard,
                 classname: generateClassName(failure.file),
                 time: utils.ms2seconds(~~failure.time)
             });


### PR DESCRIPTION
Hi,

when a test fail, I take a screenshot and add some debug info to failure.message:

```
casper.test.on("fail", function (failure) {
    "use strict";
    var capturefile = "reports/casper/" + failure.suite + "." + failure.line + ".png",
        page = "Page: " + casper.getCurrentUrl(),
        screenshot = "Screenshot: " + exports.siteUrl + "/tests/" + capturefile,
        messages = "Console: " + "\n  " + remoteMessages.join("\n  ");
    failure.message = (failure.message? failure.message : failure.standard) + "\n" + [page, screenshot, messages].join("\n");
    casper.capture(capturefile);
});
```

the problem is, the testcase will contain all this debug information.
All I want is have it in the failure node.

Thanks.
