### PR TITLE
Native use of phantomjs WebPage#reload()

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -1445,9 +1445,8 @@ Casper.prototype.open = function open(location, settings) {
 Casper.prototype.reload = function reload(then) {
     "use strict";
     this.checkStarted();
-    // window.location.reload() is broken under phantomjs
     this.then(function() {
-        this.open(this.getCurrentUrl());
+        this.page.reload();
     });
     if (utils.isFunction(then)) {
         this.then(this.createStep(then));

--- a/tests/site/form.html
+++ b/tests/site/form.html
@@ -37,6 +37,9 @@
             (function () {
                 'use strict';
 
+                // Force fields initialization
+                document.querySelector("input[name=email]").value = "";
+
                 // El-cheapo autocomplete
 
                 var choices = [

--- a/tests/suites/casper/reload.js
+++ b/tests/suites/casper/reload.js
@@ -1,0 +1,18 @@
+/*global casper*/
+/*jshint strict:false, maxstatements: 99*/
+
+casper.test.begin('reload() tests', 3, function(test) {
+    var formUrl = 'tests/site/form.html';
+
+    casper.start(formUrl, function() {
+      this.fill("form", {email: "foo@foo.com"}, false);
+    });
+    casper.once("page.resource.requested", function(resource) {
+        test.assert(resource.url.indexOf(formUrl) > 0);
+    }).reload(function() {
+        test.assertUrlMatches(formUrl);
+        test.assertField("email", "");
+    }).run(function() {
+        test.done();
+    });
+});


### PR DESCRIPTION
Refs #916, #919

This patch uses native PhantomJS `WebPage#reload()`.
