### PR TITLE
refs #915 - Fix failing examples

### DIFF
--- a/samples/bbcshots.js
+++ b/samples/bbcshots.js
@@ -1,9 +1,11 @@
 /*jshint strict:false*/
-/*global CasperError, console, phantom, require*/
+/*global CasperError, console, phantom, require, __utils__*/
 
 /**
  * Create a mosaic image from all headline photos on BBC homepage
+ * $ casperjs samples/bbcshots.js
  */
+
 var casper = require("casper").create();
 var nbLinks = 0;
 var currentLink = 1;
@@ -25,19 +27,6 @@ casper.start("http://www.bbc.co.uk/", function() {
     // hide navigation arrows
     this.hide(".nav_left");
     this.hide(".nav_right");
-    this.mouse.move("#promo2_carousel");
-});
-
-casper.waitUntilVisible(".autoplay.nav_pause", function() {
-    this.echo("Moving over pause button");
-    this.mouse.move(".autoplay.nav_pause");
-    this.click(".autoplay.nav_pause");
-    this.echo("Clicked on pause button");
-    this.waitUntilVisible(".autoplay.nav_play", function() {
-        this.echo("Carousel has been paused");
-        // hide play button
-        this.hide(".autoplay");
-    });
 });
 
 // Capture carrousel area

--- a/samples/extends.js
+++ b/samples/extends.js
@@ -1,5 +1,5 @@
 /*jshint strict:false*/
-/*global CasperError, console, phantom, require*/
+/*global CasperError, console, phantom, require, __utils__ */
 
 var casper = require("casper").create({
     loadImages: false,

--- a/samples/googlematch.js
+++ b/samples/googlematch.js
@@ -1,5 +1,5 @@
 /*jshint strict:false*/
-/*global CasperError, console, phantom, require*/
+/*global CasperError, console, phantom, require, __utils__*/
 
 /**
  * Takes provided terms passed as arguments and query google for the number of

--- a/samples/googletesting.js
+++ b/samples/googletesting.js
@@ -1,5 +1,5 @@
 /*jshint strict:false*/
-/*global CasperError, casper, console, phantom, require*/
+/*global CasperError, casper, console, phantom, require, __utils__*/
 /**
  * Google sample testing.
  *

--- a/samples/steptimeout.js
+++ b/samples/steptimeout.js
@@ -1,5 +1,9 @@
 /*jshint strict:false*/
-/*global CasperError, console, phantom, require*/
+/*global casper, CasperError, console, phantom, require*/
+
+/**
+ * $ casperjs samples/steptimout.js
+ */
 
 var failed = [];
 var start = null;
@@ -11,19 +15,17 @@ var links = [
     "http://cdiscount.fr/"
 ];
 
-var casper = require("casper").create({
-    onStepTimeout: function() {
-        failed.push(this.requestUrl);
-        this.test.fail(this.requestUrl + " loads in less than " + timeout + "ms.");
-    }
-});
+casper.options.onStepTimeout = function() {
+    failed.push(this.requestUrl);
+    this.test.fail(this.requestUrl + " loads in less than " + timeout + "ms.");
+};
 
 casper.on("load.finished", function() {
     this.echo(this.requestUrl + " loaded in " + (new Date() - start) + "ms", "PARAMETER");
 });
 
 var timeout = ~~casper.cli.get(0);
-casper.options.stepTimeout = timeout > 0 ? timeout : 1000;
+casper.options.stepTimeout = (timeout = timeout > 0 ? timeout : 1000);
 
 casper.echo("Testing with timeout=" + casper.options.stepTimeout + "ms, please be patient.");
 


### PR DESCRIPTION
Fixes some examples to be run with the `test` subcommand which would fail otherwise with:

```
Fatal: you can't override the preconfigured casper instance in a test environment.
Docs: http://docs.casperjs.org/en/latest/testing.html#test-command-args-and-options
```

Also updates some of the "globals" inline comments to satisfy jshint.

_Note:_
Since i'm currently not familiar with _CoffeeScript_ this updates _**only**_ the _JavaScript_ examples. 
