### PR TITLE
Refs #178 - plain text version for non-html contents.

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -943,36 +943,10 @@ Casper.prototype.getPageContent = function getPageContent() {
     "use strict";
     this.checkStarted();
     var contentType = utils.getPropertyPath(this, 'currentResponse.contentType');
-    if (!utils.isString(contentType)) {
+    if (!utils.isString(contentType) || contentType.indexOf("text/html") !== -1) {
         return this.page.frameContent;
     }
-    // for some reason (qt)webkit/Gecko will always enclose non text/html body contents within an html
-    // structure like this:
-    // webkit: <html><head></head><body><pre style="(...)">content</pre></body></html>
-    // gecko: <html><head><link rel="alternate stylesheet" type="text/css" href="resource://gre-resources/plaintext.css" title="..."></head><body><pre>document.write('foo');\n</pre></body></html>
-    var sanitizedHtml = this.evaluate(function checkHtml() {
-        var head = __utils__.findOne('head'),
-            body = __utils__.findOne('body');
-        if (!head || !body) {
-            return null;
-        }
-        // for content in Webkit
-        if (head.childNodes.length === 0 &&
-            body.childNodes.length === 1 &&
-            __utils__.findOne('body pre[style]')) {
-            return __utils__.findOne('body pre').textContent.trim();
-        }
-        // for content in Gecko
-        if (head.childNodes.length === 1 &&
-            body.childNodes.length === 1 &&
-            head.childNodes[0].localName === 'link' &&
-            head.childNodes[0].getAttribute('href') === 'resource://gre-resources/plaintext.css' &&
-            body.childNodes[0].localName === 'pre' ) {
-            return body.childNodes[0].textContent.trim();
-        }
-        return null;
-    });
-    return sanitizedHtml ? sanitizedHtml : this.page.frameContent;
+    return this.page.framePlainText;
 };
 
 /**

--- a/tests/suites/casper/content.js
+++ b/tests/suites/casper/content.js
@@ -13,7 +13,7 @@ casper.test.begin("Casper.getPageContent() text/html content", 1, function(test)
 
 casper.test.begin("Casper.getPageContent() non text/html content", 1, function(test) {
   casper.start("tests/site/dummy.js", function() {
-    test.assertEquals(this.getPageContent(), "document.write('foo');",
+    test.assertEquals(this.getPageContent(), "document.write('foo');\n",
                       "Casper.getPageContent() retrieves non text/html content");
   }).run(function() {
     test.done();


### PR DESCRIPTION
This fixes #178 by using the `WebPage#framePlaintext` property instead of manually parsing the generated HTML for non-html content types.
