### PR TITLE
CSS tweaks to make sidebar fixed (and individually scrollable) in docs

### DIFF
--- a/docs/_themes/casperjs/static/casperjs-dark.css
+++ b/docs/_themes/casperjs/static/casperjs-dark.css
@@ -989,3 +989,24 @@ p {
 .donate .flattr {
     margin-top: 1.5em;
 }
+
+
+/* Make sidebar fixed to keep it in window when scrolling */
+
+body { background: #333;}
+
+div.related, div.footer { margin-right: 18rem; width: auto; }
+
+div.related ul { padding-right: 4px; }
+
+div.sphinxsidebar {
+	position: fixed;
+	right: 0;
+	top: 0px;
+	height: 100%;
+	margin: 0;
+	float: none;
+	left: auto;
+	overflow: auto;
+	border-left: 2px solid #ffffff;
+}

--- a/docs/_themes/casperjs/static/casperjs-light.css
+++ b/docs/_themes/casperjs/static/casperjs-light.css
@@ -885,3 +885,20 @@ p {
     -o-filter: drop-shadow(0 1px 20px rgba(0,0,0,.5));
     filter: drop-shadow(0 1px 20px rgba(0,0,0,.5));
 }
+
+
+/* Make sidebar fixed to keep it in window when scrolling */
+
+div.related, div.footer { margin-left: 16rem; width: auto; }
+
+div.sphinxsidebar {
+	position: fixed;
+	left: 0;
+	top: 0px;
+	height: 100%;
+	margin: 0;
+	float: none;
+	right: auto;
+	overflow: auto;
+	border-left: 2px solid #ffffff;
+}


### PR DESCRIPTION
Some basic CSS tweaks to make the sidebar fixed while the page scrolls.  Looks ok in limited testing (Mac Chrome and Firefox).

Would be nice to fix the header and maybe integrate it with the sidebar, but that's a but much to tackle with no knowledge of Sphinx.

(p.s. this is my first pull request, so hopefully I'm doing everything correctly.)
