### PR TITLE
Introduce fillLabels method to fill out a form based on label text.

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -821,7 +821,7 @@ Casper.prototype.fillForm = function fillForm(selector, vals, options) {
                 var fileFieldSelector;
                 if (file.type === "names") {
                     fileFieldSelector = [selector, 'input[name="' + file.selector + '"]'].join(' ');
-                } else if (file.type === "css") {
+                } else if (file.type === "css" || file.type === "labels") {
                     fileFieldSelector = [selector, file.selector].join(' ');
                 }
                 this.page.uploadFile(fileFieldSelector, file.path);
@@ -863,6 +863,21 @@ Casper.prototype.fillNames = function fillNames(formSelector, vals, submit) {
     return this.fillForm(formSelector, vals, {
         submit: submit,
         selectorType: 'names'
+    });
+};
+
+/**
+ * Fills a form with provided field values using associated label text.
+ *
+ * @param  String  formSelector  A DOM CSS3/XPath selector to the target form to fill
+ * @param  Object  vals          Field values
+ * @param  Boolean submit        Submit the form?
+ */
+Casper.prototype.fillLabels = function fillLabels(formSelector, vals, submit) {
+    "use strict";
+    return this.fillForm(formSelector, vals, {
+        submit: submit,
+        selectorType: 'labels'
     });
 };
 

--- a/modules/clientutils.js
+++ b/modules/clientutils.js
@@ -273,6 +273,12 @@
                 css: function(inputSelector, formSelector) {
                     return this.findAll(inputSelector, form);
                 },
+                labels: function(labelText, formSelector, value) {
+                    var label = this.findOne({type: "xpath", path: '//label[text()="' + labelText + '"]'}, form);
+                    if(label && label.htmlFor) {
+                        return this.findAll('#' + label.htmlFor, form);
+                    }
+                },
                 names: function(elementName, formSelector) {
                     return this.findAll('[name="' + elementName + '"]', form);
                 },
@@ -295,9 +301,15 @@
                     out.fields[fieldSelector] = this.setField(field, value);
                 } catch (err) {
                     if (err.name === "FileUploadError") {
+                        var selector;
+                        if(findType === "labels") {
+                          selector = '#' + field[0].id;
+                        } else {
+                          selector = fieldSelector;
+                        }
                         out.files.push({
                             type: findType,
-                            selector: fieldSelector,
+                            selector: selector,
                             path: err.path
                         });
                     } else if (err.name === "FieldNotFound") {
@@ -851,9 +863,13 @@
                             };
                         case "radio":
                             if (fields) {
-                                Array.prototype.forEach.call(fields, function _forEach(e) {
-                                    e.checked = (e.value === value);
-                                });
+                                if (fields.length > 1) {
+                                    Array.prototype.forEach.call(fields, function _forEach(e) {
+                                        e.checked = (e.value === value);
+                                    });
+                                } else {
+                                    field.checked = value ? true : false;
+                                }
                             } else {
                                 out = 'Provided radio elements are empty';
                             }

--- a/tests/site/form.html
+++ b/tests/site/form.html
@@ -6,27 +6,40 @@
     </head>
     <body>
         <form action="result.html" enctype="multipart/form-data">
+            <label for="email">Email</label>
             <input type="email" name="email" placeholder="email" id="email">
-            <input type="password" name="password" placeholder="password">
+            <label for="password">Password</label>
+            <input type="password" name="password" placeholder="password" id="password">
             <input type="text" name="language" placeholder="language">
-            <input type="whatever" name="strange">
-            <textarea name="content"></textarea>
-            <select name="topic">
+            <label for="strange">Strange</label>
+            <input type="whatever" name="strange" id="strange">
+            <label for="content">Content</label>
+            <textarea name="content" id="content"></textarea>
+            <label for="topic">Topic</label>
+            <select name="topic" id="topic">
                 <option>foo</option>
                 <option value="bar">baz</option>
             </select>
-            <select multiple name="multitopic">
+            <label for="multitopic">Multitopic</label>
+            <select multiple name="multitopic" id="multitopic">
                 <option>foo</option>
                 <option value="bar">baz</option>
                 <option value="car">caz</option>
             </select>
-            <input type="checkbox" name="check">
-            <input type="radio" name="choice" value="yes">
-            <input type="radio" name="choice" value="no">
-            <input type="file" name="file">
-            <input type="checkbox" name="checklist[]" value="1">
-            <input type="checkbox" name="checklist[]" value="2">
-            <input type="checkbox" name="checklist[]" value="3">
+            <label for="check">Check</label>
+            <input type="checkbox" name="check" id="check">
+            <label for="choice_yes">Yes</label>
+            <input type="radio" name="choice" value="yes" id="choice_yes">
+            <label for="choice_no">No</label>
+            <input type="radio" name="choice" value="no" id="choice_no">
+            <label for="file">File</label>
+            <input type="file" name="file" id="file">
+            <label for="checklist_1">1</label>
+            <input type="checkbox" name="checklist[]" value="1" id="checklist_1">
+            <label for="checklist_2">2</label>
+            <input type="checkbox" name="checklist[]" value="2" id="checklist_2">
+            <label for="checklist_3">3</label>
+            <input type="checkbox" name="checklist[]" value="3" id="checklist_3">
             <input type="submit" name="submit" value="submit">
         </form>
         <form id="no-type-test-form" action="#" enctype="multipart/form-data">

--- a/tests/suites/casper/formfill.js
+++ b/tests/suites/casper/formfill.js
@@ -67,6 +67,36 @@ casper.test.begin('fill() & fillNames() tests', 17, function(test) {
     });
 });
 
+casper.test.begin('fillLabels() tests', 17, function(test) {
+    var fpath = fs.pathJoin(phantom.casperPath, 'README.md');
+
+    casper.start('tests/site/form.html', function() {
+        this.fillLabels('form[action="result.html"]', {
+            Email:         'chuck@norris.com',
+            Password:      'chuck',
+            Content:       'Am watching thou',
+            Check:         true,
+            No:            true,
+            Topic:         'bar',
+            Multitopic:    ['bar', 'car'],
+            File:          fpath,
+            "1":           true,
+            "3":           true,
+            Strange:       "very"
+        });
+        testFormValues(test);
+        test.assertEvalEquals(function() {
+            return __utils__.findOne('input[name="file"]').files.length === 1;
+        }, true, 'can select a file to upload');
+    });
+    casper.thenClick('input[type="submit"]', function() {
+        testUrl(test);
+    });
+    casper.run(function() {
+        test.done();
+    });
+});
+
 casper.test.begin('fillSelectors() tests', 17, function(test) {
     var fpath = fs.pathJoin(phantom.casperPath, 'README.md');
 


### PR DESCRIPTION
Hi folks! I've begun using it to write acceptance tests, and its a much better tool for this purpose than all the others that I've tried in JavaScript-land. So, thank you for CasperJS!

So, from the standpoint of using CasperJS as a tool to write acceptance tests, I have found one area for improvement. The problem is that the methods for interacting with forms and form elements require direct knowledge of the underlying html, specifically the name attribute of the inputs. Since acceptance tests are written from the standpoint of a non-technical user, and non-technical users don't know anything about html, css selectors, etc; associated label text is a better way of calling out form elements. This strategy also reduces the coupling between the acceptance test and the app, promoting refactoring of the html and css.

This branch is an attempt at adding this behavior to CasperJS, in the form of new fillLabels method. What do you guys think?
