### PR TITLE
refs #966 - read optional 'name' property from failure

### DIFF
--- a/docs/modules/tester.rst
+++ b/docs/modules/tester.rst
@@ -721,11 +721,12 @@ Writes an error-style formatted message to stdout::
 ``fail()``
 -------------------------------------------------------------------------------
 
-**Signature:** ``fail(String message)``
+**Signature:** ``fail(String message [, Object option])``
 
 Adds a failed test entry to the stack::
 
     casper.test.fail("Georges W. Bush");
+    casper.test.fail("Here goes a really long and expressive message", {name:'shortfacts'});
 
 .. seealso:: `pass()`_
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -246,6 +246,27 @@ You should get a pretty XUnit XML report like this:
         </testsuite>
     </testsuites>
 
+You can customize the value for the `name` property by passing an object to `casper.test.fail()` like:
+
+.. code-block:: js
+
+    casper.test.fail('google search for "casperjs" retrieves 10 or more results', {name: 'result count is 10+'});
+
+.. code-block:: xml
+
+    <?xml version="1.0" encoding="UTF-8"?>
+    <testsuites duration="1.249">
+        <testsuite errors="0" failures="0" name="Google search retrieves 10 or more results" package="googletesting" tests="5" time="1.249" timestamp="2012-12-30T21:27:26.320Z">
+            <testcase classname="googletesting" name="google homepage title is the one expected" time="0.813"/>
+            <testcase classname="googletesting" name="main form is found" time="0.002"/>
+            <testcase classname="googletesting" name="google title is ok" time="0.416"/>
+            <testcase classname="googletesting" name="search term has been submitted" time="0.017"/>
+            <testcase classname="googletesting" name="results count is 10+" time="0.001"/>
+                <failure type="fail">google search for "casperjs" retrieves 10 or more results</failure>
+            <system-out/>
+        </testsuite>
+    </testsuites>
+
 CasperJS own tests
 ------------------
 

--- a/modules/xunit.js
+++ b/modules/xunit.js
@@ -117,7 +117,7 @@ XUnitExporter.prototype.getXML = function getXML() {
         // failed test cases
         result.failures.forEach(function(failure) {
             var testCase = utils.node('testcase', {
-                name: failure.message || failure.standard,
+                name: failure.name || failure.message || failure.standard,
                 classname: generateClassName(failure.file),
                 time: utils.ms2seconds(~~failure.time)
             });

--- a/tests/suites/xunit.js
+++ b/tests/suites/xunit.js
@@ -75,3 +75,25 @@ casper.test.begin('XUnitReporter() can handle a failed test', 2, function suite(
     test.assertEquals(casper.getElementInfo('failure[type="footype"]').text, 'footext');
     test.done();
 });
+
+casper.test.begin('XUnitReporter() can handle custom name attribute for a test case', 2, function suite(test) {
+    var xunit = require('xunit').create();
+    var results = new tester.TestSuiteResult();
+    var suite1 = new tester.TestCaseResult({
+        name: 'foo',
+        file: '/foo'
+    });
+    suite1.addFailure({
+        success: false,
+        type: "footype",
+        message: "footext",
+        file: "/foo",
+        name: "foo bar baz"
+    });
+    results.push(suite1);
+    xunit.setResults(results);
+    casper.start().setContent(xunit.getSerializedXML());
+    test.assertExists('testsuite[name="foo"][package="foo"][tests="1"][failures="1"] testcase[name="foo bar baz"] failure[type="footype"]');
+    test.assertEquals(casper.getElementInfo('failure[type="footype"]').text, 'footext');
+    test.done();
+});


### PR DESCRIPTION
Allow to pass in a custom name to `casper.test.fail()` which is used in the junit xml report.

```
this.test.fail('My custom failure message', {name: 'My custom test-case name'});
```

will produce the following xml.

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites time="0.383">
    <testsuite errors="0" failures="1" name="demo" package="./custom-test-case-name" tests="1" time="0.383" timestamp="2014-07-04T11:09:11.072Z">
        <testcase classname="./custom-test-case-name" name="My custom test-case name" time="0.165">
            <failure type="fail">My custom failure message</failure>
        </testcase>
        <system-out/>
    </testsuite>
</testsuites>
```

What do you think about it guys?

best regards
~david
