### PR TITLE
ref #987 - Support for phantomjs v2.x

### DIFF
--- a/bin/bootstrap.js
+++ b/bin/bootstrap.js
@@ -110,9 +110,10 @@ CasperError.prototype = Object.getPrototypeOf(new Error());
             if (version.minor === 8 && version.patch < 1) {
                 return __die('CasperJS needs at least PhantomJS v1.8.1 or later.');
             }
-        } else if (version.major !== 2) {
-            return __die('CasperJS needs PhantomJS v1.x or v2.x');
+        } else if (version.major === 2) {
+            console.log("Warning PhantomJS v2.0 not yet released. There will not be any official support for any bugs until stable version is released!");
         }
+        else return __die('CasperJS needs PhantomJS v1.x or v2.x');
     })(phantom.version);
 
     // Hooks in default phantomjs error handler


### PR DESCRIPTION
Hi,
We were in desperate need to test websocket (xSockets v4) functionality in the app were developing. For this we had to upgrade to the very new (unstable) release of phantomjs 2.0. Currently casperjs didn't allow us to start this new version.
I have edited the bootstrap.js to allow phantomjs of version 2.x.

I hope i have done it correctly (my first PR), any feedback is appreciated. 
