### PR TITLE
add this.touch function to casper

### DIFF
--- a/docs/modules/casper.rst
+++ b/docs/modules/casper.rst
@@ -1928,6 +1928,43 @@ Returns a string representation of current Casper instance::
 
     casper.run();
 
+.. _casper_touch:
+
+.. index:: touch
+
+``touch()``
+-------------------------------------------------------------------------------
+
+**Signature:** ``touch(String selector)``
+
+Performs a touch on the element matching the provided :doc:`selector expression <../selectors>`. The method tries strategy that trying to trigger a UIEvent in Javascript.
+
+Example::
+    var casper = require("casper").create({
+        pageSettings: {
+            userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 7_0 like Mac OS X; en-us) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A465 Safari/9537.53' // Set mobile UA in the begining.
+        }
+    });
+
+    casper.start('http://www.google.com/');
+
+    casper.thenEvaluate(function(term) {
+        document.querySelector('input[name="q"]').setAttribute('value', term);
+    }, 'CasperJS');
+
+    casper.then(function() {
+        // Touch on 1st result link
+        this.touch('form[name=gs]');
+    });
+
+    casper.then(function() {
+        console.log('touched ok, new location is ' + this.getCurrentUrl());
+    });
+
+    casper.run();
+
+.. index:: touch
+
 ``unwait()``
 -------------------------------------------------------------------------------
 

--- a/modules/casper.js
+++ b/modules/casper.js
@@ -470,6 +470,29 @@ Casper.prototype.click = function click(selector) {
 };
 
 /**
+ * Emulates a touch on the element from the provided selector using the mouse
+ * pointer, if possible.
+ *
+ * In case of success, `true` is returned, `false` otherwise.
+ *
+ * @param  String   selector  A DOM CSS3 compatible selector
+ * @return Boolean
+ */
+Casper.prototype.touch = function touch(selector){
+    "use strict";
+    this.checkStarted();
+    var success = this.touchEvent('touchstart', selector) && this.touchEvent('touchend', selector);
+    this.evaluate(function(selector) {
+        var element = __utils__.findOne(selector);
+        if (element) {
+            element.focus();
+        }
+    }, selector);
+    this.emit('touch', selector);
+    return success;
+}
+
+/**
  * Emulates a click on the element having `label` as innerText. The first
  * element matching this label will be selected, so use with caution.
  *
@@ -1375,6 +1398,29 @@ Casper.prototype.mouseEvent = function mouseEvent(type, selector) {
         return this.mouse.processEvent(type, selector);
     } catch (e) {
         this.log(f("Couldn't emulate '%s' event on %s: %s", type, selector, e), "error");
+    }
+    return false;
+};
+
+/**
+ * Emulates an event on the element from the provided selector using the touch
+ * pointer, if possible.
+ *
+ * In case of success, `true` is returned, `false` otherwise.
+ *
+ * @param  String   type      Type of event to emulate
+ * @param  String   selector  A DOM CSS3 compatible selector
+ * @return Boolean
+ */
+Casper.prototype.touchEvent = function touchEvent(type, selector) {
+    "use strict";
+    this.checkStarted();
+    this.log("Touch event '" + type + "' on selector: " + selector, "debug");
+    if (!this.exists(selector)) {
+        throw new CasperError(f("Cannot dispatch %s event on nonexistent selector: %s", type, selector));
+    }
+    if (this.callUtils("touchEvent", type, selector)) {
+        return true;
     }
     return false;
 };

--- a/modules/clientutils.js
+++ b/modules/clientutils.js
@@ -707,15 +707,20 @@
                 return false;
             }
             try {
-                // Following line match W3C spec, but it is not support in the real world at this moment.
-                //var evt = document.createEvent('TouchEvent');
+                /*
+                 * Following line match W3C spec, but it is not support in the real world at this moment.
+                 * var evt = document.createEvent('TouchEvent');
+                 */
                 var evt = document.createEvent('UIEvent');
                 var center_x = 1, center_y = 1;
                 try {
                     var pos = elem.getBoundingClientRect();
                     center_x = Math.floor((pos.left + pos.right) / 2);
                     center_y = Math.floor((pos.top + pos.bottom) / 2);
-                } catch(e) {}
+                } catch(e) {
+                    this.log("Failed dispatching " + type + "touch event on " + selector + ": " + e, "error");
+                    return false;
+                }
                 evt.altKey = false;
                 evt.shiftKey = false;
                 evt.srcElement = evt.target = elem;
@@ -728,8 +733,10 @@
                 evt.touches = [touch];
                 evt.targetTouches = [touch];
                 evt.changedTouches = [touch];
-                // Following line match W3C spec, but it is not support in the real world at this moment.
-                //evt.initTouchEvent(type, true, true, window, 1, 1, 1, center_x, center_y, false, false, false, false, 0, [elem], [elem], [elem]);
+                /* 
+                 * Following line match W3C spec, but it is not support in the real world at this moment. 
+                 * evt.initTouchEvent(type, true, true, window, 1, 1, 1, center_x, center_y, false, false, false, false, 0, [elem], [elem], [elem]);
+                 */
                 evt.initUIEvent(type, true, true, window, 1, 1, 1, center_x, center_y, false, false, false, false, 0, [elem], [elem], [elem]);
                 elem.dispatchEvent(evt);
                 return true;

--- a/modules/clientutils.js
+++ b/modules/clientutils.js
@@ -694,6 +694,52 @@
         };
 
         /**
+         * Dispatches a touch event to the DOM element behind the provided selector.
+         *
+         * @param  String   type     Type of event to dispatch
+         * @param  String  selector  A CSS3 selector to the element to click
+         * @return Boolean
+         */
+        this.touchEvent = function touchEvent(type, selector){
+            var elem = this.findOne(selector);
+            if (!elem) {
+                this.log("touchEvent(): Couldn't find any element matching '" + selector + "' selector", "error");
+                return false;
+            }
+            try {
+                // Following line match W3C spec, but it is not support in the real world at this moment.
+                //var evt = document.createEvent('TouchEvent');
+                var evt = document.createEvent('UIEvent');
+                var center_x = 1, center_y = 1;
+                try {
+                    var pos = elem.getBoundingClientRect();
+                    center_x = Math.floor((pos.left + pos.right) / 2);
+                    center_y = Math.floor((pos.top + pos.bottom) / 2);
+                } catch(e) {}
+                evt.altKey = false;
+                evt.shiftKey = false;
+                evt.srcElement = evt.target = elem;
+                var touch = {
+                    pageX: center_x,
+                    pageY: center_y,
+                    clientX: center_x - elem.scrollLeft,
+                    clientY: center_y - elem.scrollTop,
+                    target: elem};
+                evt.touches = [touch];
+                evt.targetTouches = [touch];
+                evt.changedTouches = [touch];
+                // Following line match W3C spec, but it is not support in the real world at this moment.
+                //evt.initTouchEvent(type, true, true, window, 1, 1, 1, center_x, center_y, false, false, false, false, 0, [elem], [elem], [elem]);
+                evt.initUIEvent(type, true, true, window, 1, 1, 1, center_x, center_y, false, false, false, false, 0, [elem], [elem], [elem]);
+                elem.dispatchEvent(evt);
+                return true;
+            } catch (e) {
+                this.log("Failed dispatching " + type + "touch event on " + selector + ": " + e, "error");
+                return false;
+            }
+        };
+
+        /**
          * Processes a selector input, either as a string or an object.
          *
          * If passed an object, if must be of the form:

--- a/tests/site/touch.html
+++ b/tests/site/touch.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <title>CasperJS test touch</title>
+    </head>
+    <body>
+        <div id="test1">test1</div>
+        <div id="test2" ontouchstart="results.test2 = true;">test2</div>
+        <div id="test3" ontouchstart="results.test3 = true; return false">test3</div>
+        <div id="test5">test3</div>
+        <script>
+            (function(window) {
+                window.results = {
+                    test1: false,
+                    test2: false,
+                    test3: false,
+                    test5: []
+                };
+                document.querySelector('#test1').ontouchstart = function(event) {
+                    results.test1 = true;
+                    event.preventDefault();
+                };
+            var test5elem = document.querySelector('#test5');
+                test5elem.addEventListener('touchstart', function(event) {
+                    results.test5.push('touchstart');
+                });
+                test5elem.addEventListener('touchmove', function(event) {
+                    results.test5.push('touchmove');
+                });
+                test5elem.addEventListener('touchend', function(event) {
+                    results.test5.push('touchend');
+                });
+            })(window);
+        </script>
+    </body>
+</html>

--- a/tests/suites/casper/touch.js
+++ b/tests/suites/casper/touch.js
@@ -1,0 +1,38 @@
+/*global casper*/
+/*jshint strict:false, maxstatements: 99*/
+var utils = require('utils');
+
+casper.test.begin('ontouch variants tests', 6, function(test) {
+    casper.start('tests/site/touch.html', function() {
+        test.assert(this.touch('#test1'), 'Casper.touch() can touch an unobstrusive js handled div');
+        test.assert(this.touch('#test2'), 'Casper.touch() can touch an `ontouch=".*"` div');
+        test.assert(this.touch('#test3'), 'Casper.touch() can touch an `ontouch=".*; return false"` div');
+        var results = this.getGlobal('results');
+        if (phantom.casperEngine === 'slimerjs') {
+            // "javascript:" link in Gecko are executed asynchronously, so we don't have result at this time
+            test.skip(1)
+        }
+        else
+            test.assert(results.test1, 'Casper.touch() has touched an unobstrusive js handled div');
+        test.assert(results.test2, 'Casper.touch() has touched an `ontouch=".*"` div');
+        test.assert(results.test3, 'Casper.touch() has touched an `ontouch=".*; return false"` div');
+    }).run(function() {
+        test.done();
+    });
+});
+
+casper.test.begin('touch events on touch', 3, function(test) {
+    casper.start('tests/site/touch.html', function() {
+        this.touch('#test5');
+    }).then(function() {
+        var results = this.getGlobal('results');
+        test.assert(results.test5.indexOf('touchstart') !== -1,
+            'Casper.touch() triggers touchstart event');
+        test.assert(results.test5.indexOf('touchmove') == -1,
+            'Casper.touch() doesn\'t trigger touchmove event');
+        test.assert(results.test5.indexOf('touchend') !== -1,
+            'Casper.touch() triggers touchend event');
+    }).run(function() {
+        test.done();
+    });
+});

--- a/tests/suites/casper/touch.js
+++ b/tests/suites/casper/touch.js
@@ -28,7 +28,7 @@ casper.test.begin('touch events on touch', 3, function(test) {
         var results = this.getGlobal('results');
         test.assert(results.test5.indexOf('touchstart') !== -1,
             'Casper.touch() triggers touchstart event');
-        test.assert(results.test5.indexOf('touchmove') == -1,
+        test.assert(results.test5.indexOf('touchmove') === -1,
             'Casper.touch() doesn\'t trigger touchmove event');
         test.assert(results.test5.indexOf('touchend') !== -1,
             'Casper.touch() triggers touchend event');


### PR DESCRIPTION
One of My friends failed to use casperjs to write test case in mobile web page testing, because this web page use touch event to trigger a action, but capserjs only support click event. I wrote following codes to make touch event available in capserjs, and I think a touch event supporting in mobile web page testing is necessary, as the touch event in cellphone is very common. So I commit my patch back to capserjs, and hope it helps others.