### PR TITLE
rpm/build topdir fix for BSD mktemp

### DIFF
--- a/rpm/build
+++ b/rpm/build
@@ -9,7 +9,7 @@ fi
 
 name="casperjs"
 name=${name%.spec}
-topdir=$(mktemp -d)
+topdir=$(mktemp -d "${TMPDIR:-/tmp}/${name}-build-XXXXXX")
 # Get version from package.json
 version=$(grep '"version"' ../package.json | sed 's/.*"\(.*\)": "\(.*\)".*/\2/' | sed 's/[-]//')
 builddir=${TMPDIR:-/tmp}/${name}-${version}


### PR DESCRIPTION
BSD mktemp needs an argument to provide an appropriate path. This update provides a working path directory in both Linux and Mac OSX.
