### PR TITLE
 page.resource.requsted event never fires on urlencoded or encoded urls

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -2599,7 +2599,7 @@ function createPage(casper) {
     };
     page.onResourceRequested = function onResourceRequested(requestData, request) {
         casper.emit('resource.requested', requestData, request);
-        if (requestData.url === casper.requestUrl) {
+        if (utils.decodeUrl(requestData.url) === casper.requestUrl) {
             casper.emit('page.resource.requested', requestData, request);
         }
         if (utils.isFunction(casper.options.onResourceRequested)) {

--- a/tests/suites/casper/pagerequest.js
+++ b/tests/suites/casper/pagerequest.js
@@ -1,0 +1,101 @@
+/*global casper*/
+/*jshint strict:false*/
+/* jshint -W100 */
+casper.test.begin('event page.resource.requested tests', 4, function (test) {
+
+    var pageResourceRequested = false;
+    var pageResourceReceived = false;
+
+    casper.on('page.resource.requested', function () {
+        pageResourceRequested = true;
+    });
+    casper.on('page.resource.received', function () {
+        pageResourceReceived = true;
+    });
+
+    casper.start('tests/site/urls.html', function () {
+        rawUnicodeUrlTest();
+    });
+
+    var rawUnicodeUrlTest = function () {
+        casper.waitFor(function () {
+            return pageResourceRequested === true
+        }, function () {
+            casper.test.pass('page.resource.requested called on raw unicode url');
+        }, function () {
+            casper.test.fail('page.resource.requested was not called on raw unicode url')
+        }, 200);
+
+        casper.waitFor(function () {
+            return pageResourceReceived === true
+        }, function () {
+            casper.test.pass('page.resource.received called on raw unicode url');
+            uriEncodedUrlTest();
+        }, function () {
+            casper.test.fail('page.resource.received was not called on raw unicode url')
+        }, 200);
+
+        pageResourceRequested = false;
+        pageResourceReceived = false;
+
+        casper.clickLabel('raw unicode', 'a');
+    };
+
+    var uriEncodedUrlTest = function () {
+        casper.waitFor(function () {
+            return pageResourceRequested === true
+        }, function () {
+            casper.test.pass('page.resource.requested called on uri encoded url');
+        }, function () {
+            casper.test.fail('page.resource.requested was not called on uri encoded url')
+        }, 200);
+
+        casper.waitFor(function () {
+            return pageResourceReceived === true
+        }, function () {
+            casper.test.pass('page.resource.received called on uri encoded url');
+            // This test fails because of PhantomJS bug
+            //escapedUrlTest();
+        }, function () {
+            casper.test.fail('page.resource.received was not called on uri encoded url')
+        }, 200);
+
+        pageResourceRequested = false;
+        pageResourceReceived = false;
+
+        casper.clickLabel('uri encoded', 'a');
+    };
+
+    // this test fails, because page.onNavigationRequested event get not correctly escaped url from PhantomJS:
+    // console.log(casper.requestUrl) -> http://localhost:54321/tests/site/urls.html?test=Forl�
+    // Chrome and Firefox do not escape this URL at all (/urls.html?test=Forl%EC)
+    // We could unescape it, but it will still not be equal equal with the PhantomJS one
+    // console.log(unescape(requestData.url)) -> http://localhost:54321/tests/site/urls.html?test=Forlì
+    var escapedUrlTest = function () {
+        casper.waitFor(function () {
+            return pageResourceRequested === true
+        }, function () {
+            casper.test.pass('page.resource.requested called on escaped url');
+        }, function () {
+            casper.test.fail('page.resource.requested was not called on escaped url')
+        }, 200);
+
+        casper.waitFor(function () {
+            return pageResourceReceived === true
+        }, function () {
+            casper.test.pass('page.resource.received called on escaped url');
+        }, function () {
+            casper.test.fail('page.resource.received was not called on escaped url')
+        }, 200);
+
+        pageResourceRequested = false;
+        pageResourceReceived = false;
+
+        casper.clickLabel('escaped', 'a');
+    };
+
+    casper.run(function () {
+        test.done();
+    });
+});
+


### PR DESCRIPTION
We are using the **"page.resource.requsted"** event to measure the page loading times. But we noticed, that on the urls with russian symbols (they are mostly urlencoded, look at ru.wikipedia.org) these event were never fired! 

The problem was in the _page.onResourceRequested()_ function. It compares the requested URL with the current page URL to check if the **"page.resource.requsted"** event can be fired. But PhantomJS (as well as Chrome of FF) requests the URL urlencoded, so the comparison never succeeds on urlencoded urls.

I've added the code for decoding the URL before the comparison, and the event **"page.resource.requsted"** is now fired on ulrencoded URLs. I've also added tests for this case.

But the tests has detected the problem with not correctly urlencoded urls: the event **"page.resource.requsted"** is not fired on URLs which were created with _escape()_ function. After some digging, I think, that the problem is on the PhantomJS side. The **page.onNavigationRequested** event is fired from PhantomJS and gets as an argumen not correctly escaped url : `console.log(casper.requestUrl) -> http://localhost:54321/tests/site/urls.html?test=Forl�`. For example, Chrome and Firefox do not escape this URL at all (`/urls.html?test=Forl%EC`). We could unescape this URL, but it will still not be equal  with the PhantomJS one `console.log(unescape(requestData.url)) -> http://localhost:54321/tests/site/urls.html?test=Forlì`

**Edit:** I have noticed, that  the **"page.resource.received"** event suffers from this bug and extended the tests to include it.

I have commented the unit test which checks the escaped URL, so the PR could be merged, but the problem with escaped URLs is still there.
I have not so much experience with PhantomJS or CasperJS to fix it directly, but would like to discuss it to find the way to do it.
