### PR TITLE
TestRunner curTestSuiteNum Bug Fix

### DIFF
--- a/tests/suites/tester/test-suite-nums.js
+++ b/tests/suites/tester/test-suite-nums.js
@@ -1,0 +1,16 @@
+/*jshint strict:false*/
+/*global CasperError, casper, console, phantom, require*/
+var fs = require('fs');
+
+casper.test.begin('Testsuite 0', 1, function suite(test) {
+    test.assertEquals(test.currentSuiteNum, 0, 'first suite is #0');
+    test.done();
+});
+casper.test.begin('Testsuite 1', 1, function suite(test) {
+    test.assertEquals(test.currentSuiteNum, 1, 'first suite is #1');
+    test.done();
+});
+casper.test.begin('Testsuite 2', 1, function suite(test) {
+    test.assertEquals(test.currentSuiteNum, 2, 'first suite is #2');
+    test.done();
+});


### PR DESCRIPTION
(this pull request is a cleaned up version of the now-closed PR #937)

Currently curTestSuiteNum is updated for every file that is run, restricting each file to one test suite per file.

This was causing issues in files with multiple sets of tests:
- stepTimeout uses an id of <filenum>_<stepnum>, and stepTimeout stops polling if the id matches
- if a subsequent testSuite runs in the same file, it will have the same testSuiteId, causing potential misfires of stepTimeout

This separates file count from test suite count, eliminating the stepTimeout problem, and allowing multiple testSuites per file.
