### PR TITLE
refs #1032 - Don't use a regexp search for string search in resourceExists

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -1488,7 +1488,7 @@ Casper.prototype.resourceExists = function resourceExists(test) {
     switch (utils.betterTypeOf(test)) {
         case "string":
             testFn = function _testResourceExists_String(res) {
-                return res.url.search(test) !== -1 && res.status !== 404;
+                return res.url.indexOf(test) !== -1 && res.status !== 404;
             };
             break;
         case "regexp":

--- a/tests/site/resources.html
+++ b/tests/site/resources.html
@@ -8,7 +8,7 @@
       <script id="loader"></script>
       <script>
         setTimeout(function () {
-          document.querySelector("#loader").setAttribute("src", "dummy.js");
+          document.querySelector("#loader").setAttribute("src", "dummy.js?querystring");
         }, 1000);
       </script>
     </body>

--- a/tests/suites/casper/resources.js
+++ b/tests/suites/casper/resources.js
@@ -11,7 +11,7 @@ casper.test.begin("Basic resources tests", 5, function(test) {
     test.assertResourceExists(function(res) {
       return res.url.match("dummy.js");
     }, "phantom image found via test Function");
-    test.assertResourceExists("dummy.js", "phantom image found via test String");
+    test.assertResourceExists("dummy.js?querystring", "phantom image found via test String");
   }, function onTimeout() {
     test.fail("waitForResource timeout occured");
   });


### PR DESCRIPTION
This fixes the issue described in #1032.
