### PR TITLE
Adding a test to check that text can be fetched from the value attribute

### DIFF
--- a/tests/suites/casper/fetchtext.js
+++ b/tests/suites/casper/fetchtext.js
@@ -9,6 +9,15 @@ casper.test.begin('fetchText() basic tests', 1, function(test) {
     });
 });
 
+casper.test.begin('fetchText() basic tests', 1, function(test) {
+    casper.start('tests/site/index.html', function() {
+        test.assertEquals(this.fetchText('input[name="dummy_name"]'), 'dummy_value',
+            'Casper.fetchText() can retrieve text contents from an input element');
+    }).run(function() {
+        test.done();
+    });
+});
+
 casper.test.begin('fetchText() handles HTML entities', 1, function(test) {
     casper.start().then(function() {
         this.setContent('<html><body>Voil&agrave;</body></html>');


### PR DESCRIPTION
Adding a test to expose an issue where waitForSelectorTextChange (which uses ClientUtils.fetchText) should pick up changes in input elements, but isn't currently.

Refer to Issue: https://github.com/n1k0/casperjs/issues/1078
Fixed in PR: https://github.com/n1k0/casperjs/pull/1079
