### PR TITLE
refs #1099 - add getElement and getElements functions to the casper module 

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -1048,6 +1048,36 @@ Casper.prototype.getElementBounds = function getElementBounds(selector) {
 };
 
 /**
+ * Retrieves the node matching the provided selector.
+ *
+ * @param  String|Objects  selector  CSS3/XPath selector
+ * @return Object
+ */
+Casper.prototype.getElement = function getElement(selector) {
+    "use strict";
+    this.checkStarted();
+    if (!this.exists(selector)) {
+        throw new CasperError(f("Cannot get informations from %s: element not found.", selector));
+    }
+    return this.callUtils("getElement", selector);
+};
+
+/**
+ * Retrieves the node matching the provided selector.
+ *
+ * @param  String|Objects  selector  CSS3/XPath selector
+ * @return Object
+ */
+Casper.prototype.getElements = function getElements(selector) {
+    "use strict";
+    this.checkStarted();
+    if (!this.exists(selector)) {
+        throw new CasperError(f("Cannot get informations from %s: element not found.", selector));
+    }
+    return this.callUtils("getElements", selector);
+};
+
+/**
  * Retrieves information about the node matching the provided selector.
  *
  * @param  String|Objects  selector  CSS3/XPath selector

--- a/modules/clientutils.js
+++ b/modules/clientutils.js
@@ -467,6 +467,34 @@
         };
 
         /**
+         * Retrieves an element as an Element of a Document in the current scope
+         * (See: https://developer.mozilla.org/en-US/docs/Web/API/document.querySelector)
+         *
+         * @param String|Object selector CSS3/XPath selector 
+         * @return Object
+        */
+        this.getElement = function getElement(selector) {
+            var element = this.findOne(selector);
+
+            return element;
+        };
+
+        /**
+         * Retrieves an array of elements as an Element of a Document in the current scope
+         * (See: https://developer.mozilla.org/en-US/docs/Web/API/document.querySelector)
+         *
+         * @param String|Object selector CSS3/XPath selector 
+         * @return Array
+        */
+        this.getElements = function getElements(selector) {
+            var elements = this.findAll(selector);
+            var elementsArray = [].slice.call(elements);
+
+            return elementsArray;
+        };
+
+
+        /**
          * Retrieves information about the node matching the provided selector.
          *
          * @param  String|Object  selector  CSS3/XPath selector

--- a/tests/suites/clientutils.js
+++ b/tests/suites/clientutils.js
@@ -171,6 +171,25 @@ casper.test.begin('ClientUtils.getElementBounds() page zoom factor tests', 3, fu
     });
 });
 
+casper.test.begin('ClientUtils.getElement() tests', 2, function(test) {
+    casper.page.content = '<a href="plop" class="plip plup"><i>paf</i></a>';
+    var element = casper.getElement('a.plip');
+    test.assert(element !== null, 'ClientUtils.getElement() retrieves element');
+    test.assertEquals(element.tagName, 'A', 'ClientUtils.getElement() retrieves the correct element tagName');
+   
+    test.done();
+});
+
+casper.test.begin('ClientUtils.getElements() second element tests', 2, function(test) {
+    casper.page.content = '<a href="plop" class="plip plup"><i>paf</i></a><a href="plap" class="plip plup"><i>puf</i></a><a href="plip"><i>fup</i></a>';
+    var elements = casper.getElements('a.plip');
+    test.assertType(elements, 'array',
+        'ClientUtils.getElements() can find matching DOM elements');
+    test.assert(elements.length === 2, 'ClientUtils.getElements() retrieves the correct elements');
+
+    test.done();
+});
+
 casper.test.begin('ClientUtils.getElementInfo() tests', 10, function(test) {
     casper.page.content = '<a href="plop" class="plip plup"><i>paf</i></a>';
     var info = casper.getElementInfo('a.plip');


### PR DESCRIPTION
Add 2 functions to the casper module:
- getElement
- getElements

They provide a way to fetch DOM nodes with scope attached to them, so further manipulations and operations like using querySelector can be done.
