### PR TITLE
Added encoding option for open()

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -1433,7 +1433,8 @@ Casper.prototype.open = function open(location, settings) {
     this.browserInitializing = true;
     this.page.openUrl(this.requestUrl, {
         operation: settings.method,
-        data:      settings.data
+        data:      settings.data,
+        encoding:  settings.encoding
     }, this.page.settings);
     // revert base custom headers
     this.page.customHeaders = baseCustomHeaders;


### PR DESCRIPTION
We ran into encoding issues  posting xml content to our test server using open(). 
To fix that we pass-through the encoding settings to phantomjs' openUrl() . 
