### PR TITLE
refs #1236 - Fixing multiple redirects handling using SlimerJS engine

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Sample commit message:
 
 Run CasperJS' test suite to see you didn't break something:
 
-    $ casperjs selftest && casper selftest --engine=slimerjs
+    $ casperjs selftest && casperjs selftest --engine=slimerjs
 
 The result status bar **must be green** before sending your PR.
 

--- a/modules/casper.js
+++ b/modules/casper.js
@@ -2612,6 +2612,7 @@ function createPage(casper) {
     page.onUrlChanged = function onUrlChanged(url) {
         casper.log(f('url changed to "%s"', url), "debug");
         casper.navigationRequested = false;
+        casper.requestUrl = url;
         casper.emit('url.changed', url);
     };
     casper.emit('page.created', page);

--- a/tests/run.js
+++ b/tests/run.js
@@ -102,7 +102,7 @@ function initRunner() {
     // test suites completion listener
     casper.test.on('tests.complete', function() {
         this.renderResults(this.options.autoExit, undefined, casper.cli.get('xunit') || undefined);
-        if (this.options.failFast && this.testResults.failures.length > 0) {
+        if (this.options.failFast && this.suiteResults.countFailed() > 0) {
             casper.warn('Test suite failed fast, all tests may not have been executed.');
         }
     });

--- a/tests/site/redirect.html
+++ b/tests/site/redirect.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <title>CasperJS redirect tests</title>
+    </head>
+    <body>
+        Hello CasperJS
+        <script type="text/javascript">
+            window.addEventListener('load', function() {
+                window.location.hash = '#test';
+            });
+        </script>
+    </body>
+</html>

--- a/tests/suites/redirect.js
+++ b/tests/suites/redirect.js
@@ -1,0 +1,42 @@
+/*eslint strict:0*/
+/**
+ * Special test server to test for HTTP status codes
+ *
+ */
+var fs = require('fs');
+
+casper.test.begin('HTTP Redirect handling', 1, {
+    setUp: function() {
+        var pageFile = fs.pathJoin(phantom.casperPath, 'tests/site/redirect.html');
+
+        this.server = require('webserver').create();
+        this.server.listen(8090, function (request, response) {
+            if (request.url === '/redirect') {
+                response.statusCode = 302;
+                response.setHeader('Location', '/hello');
+                response.write('');
+            } else {
+                response.statusCode = 200;
+                response.write(fs.read(pageFile));
+            }
+            response.close();
+        });
+    },
+
+    tearDown: function() {
+        this.server.close();
+    },
+
+    test: function() {
+        casper.start();
+
+        // Redirect
+        casper.thenOpen('http://localhost:8090/redirect', function() {
+            this.test.assert(true, 'Assert that the page has been fully loaded');
+        });
+
+        casper.run(function() {
+            this.test.done();
+        });
+    }
+});


### PR DESCRIPTION
Fixing the strange redirect behavior when using SlimerJS' engine.

To run the specific test:

``` bash
bin/casperjs selftest --engine=slimerjs tests/suites/redirect.js
```

This will cause CasperJS to hang before using the fix
