### PR TITLE
Added getFieldValue to Casper prototype

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -1118,6 +1118,15 @@ Casper.prototype.getFormValues = function(selector) {
     return this.callUtils("getFormValues", selector);
 };
 
+Casper.prototype.getFieldValue = function(selector) {
+	"use strict";
+	this.checkStarted();
+	if (!this.exists(selector)) {
+		throw new CasperError(f('Field matching selector "%s" not found', selector));
+	};
+	return this.callUtils("getFieldValue", selector);
+};
+
 /**
  * Retrieves global variable.
  *


### PR DESCRIPTION
Made it more convenient to use the callUtils getFieldValue by adding it to the Casper prototype. Allows for cleaner scripting.
