### PR TITLE
Docs: Update optional params to evaluateOrDie

### DIFF
--- a/docs/modules/casper.rst
+++ b/docs/modules/casper.rst
@@ -816,7 +816,7 @@ Basically `PhantomJS' WebPage#evaluate <http://phantomjs.org/api/webpage/method/
 ``evaluateOrDie()``
 -------------------------------------------------------------------------------
 
-**Signature:** ``evaluateOrDie(Function fn[, String message])``
+**Signature:** ``evaluateOrDie(Function fn[, String message, int status])``
 
 Evaluates an expression within the current page DOM and ``die()`` if it returns anything but ``true``::
 


### PR DESCRIPTION
evaluateOrDie is already capable of passing a custom status code to die. Just updating the docs to reflect this.