### PR TITLE
Prevent hangs on timeout in slimerjs

### DIFF
--- a/modules/tester.js
+++ b/modules/tester.js
@@ -214,11 +214,11 @@ var Tester = function Tester(casper, options) {
 
     // specific timeout callbacks
     this.casper.options.onStepTimeout = function test_onStepTimeout(timeout, step) {
-        throw new TimedOutError(f("Step timeout occured at step %s (%dms)", step, timeout));
+        errorHandlerAndDone(new TimedOutError(f("Step timeout occured at step %s (%dms)", step, timeout)));
     };
 
     this.casper.options.onTimeout = function test_onTimeout(timeout) {
-        throw new TimedOutError(f("Timeout occured (%dms)", timeout));
+        errorHandlerAndDone(new TimedOutError(f("Timeout occured (%dms)", timeout)));
     };
 
     this.casper.options.onWaitTimeout = function test_onWaitTimeout(timeout, details) {
@@ -1211,6 +1211,13 @@ Tester.prototype.done = function done() {
             this.executed = 0;
         }
         this.emit('test.done');
+
+        // Reset all the state that blocks the next step from running
+        this.casper.pendingWait = false;
+        this.casper.loadInProgress = false;
+        this.casper.navigationRequested = false;
+        this.casper.browserInitializing = false;
+
         this.casper.currentHTTPResponse = {};
         this.running = this.started = false;
         var nextTest = this.queue.shift();


### PR DESCRIPTION
Slimerjs appears to incorrectly implement `phantom.onError`. This results in
hangs when a test or a step times out in casperjs.

Relevant slimerjs bug is tracked here: https://github.com/laurentj/slimerjs/issues/406

This PR deals with that bug in slimerjs by using `errorHandlerAndDone` instead of throwing an exception. This is a similar code path to how `onWaitTimeout` works in `modules/tester.js`. 

To reproduce the problem in casperjs, put the following in `/tmp/test.js`:

``` js
casper.options.timeout = 1000;
casper.options.stepTimeout = 100;

casper.test.begin("should timeout after 100ms", function(test) {
  casper.start();
});

casper.test.begin("should timeout after 50ms", function(test) {
  casper.start();
  casper.then(function() {
    casper.waitStart();
  });
  casper.run();
});
```

Then run:

```
$ bin/casperjs --engine=slimerjs test /tmp/test.js
Test file: /tmp/test.js
# should timeout after 100ms
PASS should timeout after 100ms (NaN test)
```

And it will hang after the `PASS`.

If you run the same thing with phantomjs, it times out as you'd expect:

```
$ bin/casperjs --engine=phantomjs test /tmp/test.js
Test file: /tmp/test.js
# should timeout after 100ms
PASS should timeout after 100ms (NaN test)
FAIL Timeout occured (1000ms)
#    type: uncaughtError
#    file: /tmp/test.js
#    error: Timeout occured (1000ms)

#    stack: not provided
# should timeout after 50ms
PASS should timeout after 50ms (NaN test)
FAIL Step timeout occured at step 1-1 (100ms)
#    type: uncaughtError
#    file: /tmp/test.js
#    error: Step timeout occured at step 1-1 (100ms)

#    stack: not provided
FAIL 2 tests executed in 1.254s, 0 passed, 2 failed, 0 dubious, 0 skipped.

Details for the 2 failed tests:

In /tmp/test.js
  should timeout after 100ms
    uncaughtError: Timeout occured (1000ms)
In /tmp/test.js
  should timeout after 50ms
    uncaughtError: Step timeout occured at step 1-1 (100ms)
```
