### PR TITLE
add features stop and abort

### DIFF
--- a/docs/modules/casper.rst
+++ b/docs/modules/casper.rst
@@ -386,6 +386,28 @@ Default wait timeout, for ``wait*`` family functions.
 ``Casper`` prototype
 ++++++++++++++++++++
 
+``abort()``
+-------------------------------------------------------------------------------
+
+**Signature:** ``abort(Function onAbort)``
+
+Aborts running Casper without onComplete call.::
+
+    casper.start('http://foo.bar/1')
+    casper.then(function(){
+       this.abort(function onAbort(){
+          console.log("finished : display");
+       });
+    });    
+    casper.then(function(){
+       this.echo("not display");
+    }); 
+    casper.run(function() {
+        console.log("finished : not display");
+    });
+
+Also have a look at `run()`_.
+
 ``back()``
 -------------------------------------------------------------------------------
 
@@ -1707,6 +1729,26 @@ Returns the status of current Casper instance::
     });
 
     casper.run();
+
+``stop()``
+-------------------------------------------------------------------------------
+
+**Signature:** ``stop()``
+
+Stops running Casper with onComplete call.::
+
+    casper.start('http://foo.bar/1')
+    casper.then(function(){
+       this.stop();
+    });    
+    casper.then(function(){
+       this.echo("not display");
+    }); 
+    casper.run(function() {
+        console.log("finished : display");
+    });
+
+Also have a look at `run()`_.
 
 .. index:: Step stack, Asynchronicity
 

--- a/tests/suites/casper/stop.js
+++ b/tests/suites/casper/stop.js
@@ -1,0 +1,165 @@
+/*eslint strict:0*/
+
+casper.test.begin('Casper.stop() can stop before to run test', 1, function(test) {
+    casper.start();
+    casper.then(function(){
+        test.fail("This test should not be executed.");
+    });
+    casper.stop().run(function() {
+        test.pass("run has been stopped");
+        test.done();
+    });
+});
+
+
+casper.test.begin('Casper.stop() can stop a running test', 2, function(test) {
+    casper.start();
+    casper.then(function(){
+        test.pass("This test should be executed.");
+        casper.stop();
+    });
+    casper.then(function(){
+        test.fail("This test should not be executed.");
+    });    
+    casper.run(function() {
+        test.pass("run has been stopped");
+        test.done();
+    });
+});
+
+casper.test.begin('Casper.stop() can stop on timeout', 1, function(test) {
+    casper.start();
+    var onWaitTimeoutFn = casper.options.onWaitTimeout;
+    var waitTimeoutVar = casper.options.waitTimeout;
+    casper.options.waitTimeout = 500;
+
+    casper.options.onWaitTimeout = function _onWaitTimeout(timeout) {
+        this.options.onWaitTimeout = onWaitTimeoutFn;
+        this.options.waitTimeout = waitTimeoutVar;        
+        this.stop();
+    };
+
+    casper.then(function(){
+        this.waitFor(function check() {
+            return 1 === 0;
+        },function(){});
+    });
+    casper.then(function(){
+        test.fail("This test should not be executed.");
+    });    
+    casper.run(function() {
+        test.pass("run has been stopped");
+        test.done();
+    });
+});
+
+casper.test.begin('Casper.stop() and restart a new run', 2, function(test) {
+    casper.start();
+    casper.then(function(){
+        test.fail("This test should not be executed.");
+    });
+    casper.stop().run(function() {
+        casper.start();
+        casper.then(function(){
+            test.pass("This test should not be executed.");
+        });
+        casper.run(function() {
+            test.pass("run has been stopped");
+            test.done();
+        });
+    });
+});
+
+//----------------------------------------------------------------------
+casper.test.begin('Casper.abort() can stop before to run test', 1, function(test) {
+    casper.start();
+    casper.then(function(){
+        test.fail("This test should not be executed.");
+    });
+    casper.abort(function(){
+        test.pass("run has been aborted");
+        test.done();
+    });
+    casper.run(function() {
+        test.fail("run has not been aborted");
+        
+    });
+});
+
+casper.test.begin('Casper.abort() can stop a running test', 2, function(test) {
+    casper.start();
+    casper.then(function(){
+        test.pass("This test should be executed.");
+        casper.abort(function(){
+            test.pass("run has been aborted");
+            test.done();
+        });
+    });
+    casper.then(function(){
+        test.fail("This test should not be executed.");
+    });    
+    casper.run(function() {
+        test.fail("run has not been aborted");
+        test.done();
+    });
+});
+
+//
+
+casper.test.begin('Casper.abort() can stop on timeout', 1, function(test) {
+    casper.start();
+    var onWaitTimeoutFn = casper.options.onWaitTimeout;
+    var waitTimeoutVar = casper.options.waitTimeout;
+    casper.options.waitTimeout = 500;
+
+    casper.options.onWaitTimeout = function _onWaitTimeout(timeout) {
+        this.options.onWaitTimeout = onWaitTimeoutFn;
+        this.options.waitTimeout = waitTimeoutVar;    
+        casper.abort(function(){
+            test.pass("run has been aborted");
+            test.done();
+        });
+    };
+
+    casper.then(function(){
+        this.waitFor(function check() {
+            return 1 === 0;
+        },function(){});
+    });
+    casper.then(function(){
+        test.fail("This test should not be executed.");
+    });    
+    casper.run(function() {
+        test.fail("run has not been aborted");
+    });
+});
+
+casper.test.begin('Casper.abort() and restart a new run', 3, function(test) {
+    casper.start();
+    casper.then(function(){
+        test.fail("This test should not be executed.");
+    });
+    
+    casper.abort(function(){
+        test.pass("run has been aborted");
+        casper.start();
+        casper.then(function(){
+            test.pass("This test should not be executed.");
+        });
+        casper.run(function() {
+            test.pass("This test should not be executed.");
+            test.done();
+        });
+    });
+        
+    casper.run(function() {
+        test.fail("run has not been aborted");
+        casper.start();
+        casper.then(function(){
+            test.pass("This test should not be executed.");
+        });
+        casper.run(function() {
+            
+        });
+    });
+});


### PR DESCRIPTION
This patch adds 2 methods to Casper Object : 
- stop : stops running loop and execute onCompete callback
- abort : stops running loop and but do not execute onCompete callback
