### PR TITLE
features add step.bypassed event

### DIFF
--- a/docs/events-filters.rst
+++ b/docs/events-filters.rst
@@ -462,6 +462,13 @@ Emitted when Casper has been started using ``Casper.start()``.
 
 Emitted when a new navigation step has been added to the stack.
 
+``step.bypassed``
+~~~~~~~~~~~~~~
+
+**Arguments:** ``step, step``
+
+Emitted when a new navigation step has been reached by bypass (destination, origin).
+
 ``step.complete``
 ~~~~~~~~~~~~~~~~~
 

--- a/modules/casper.js
+++ b/modules/casper.js
@@ -270,9 +270,11 @@ Casper.prototype.bypass = function bypass(nb) {
     "use strict";
     var step = this.step,
         steps = this.steps,
-        last = steps.length;
+        last = steps.length,
+        targetStep = Math.min(step + nb, last);
     this.checkStarted();
-    this.step = Math.min(step + nb, last);
+    this.step = targetStep;
+    this.emit('step.bypassed', targetStep, step);
     return this;
 };
 

--- a/tests/suites/casper/bypass.js
+++ b/tests/suites/casper/bypass.js
@@ -1,10 +1,12 @@
 /*eslint strict:0*/
-casper.test.begin('Casper.bypass() can bypass a step', 1, function(test) {
+casper.test.begin('Casper.bypass() can bypass a step', 2, function(test) {
     casper.start();
     casper.then(function(){
         test.fail("This test should not be executed.");
     });
-    casper.bypass(1).run(function() {
+    casper.once("step.bypassed", function(step) {
+        test.pass("step.bypassed event has been catched");
+    }).bypass(1).run(function() {
         test.pass("Step has been bypassed");
         test.done();
     });
@@ -103,4 +105,3 @@ casper.test.begin('Casper.thenBypassUnless()', 3, function(test) {
         test.done();
     });
 });
-


### PR DESCRIPTION
Just inform that casper.bypass method has been used
- 2 parameters emit destination Step and source Step

example : 


```
casper.start();

casper.once("step.bypassed", function(step) {
        this.echo("step.bypassed event has been catched");
})
casper.bypass(1).run(function() {
   this.exit(0);
});
```