### PR TITLE
refs #1439 - adding methods setFieldValue, setFieldValueName, setFiel…

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -1686,6 +1686,62 @@ Casper.prototype.setContent = function setContent(content) {
     return this;
 };
 
+
+/**
+ * Sets a value to form field by CSS3, XPath selector or by it's name attribute or label text.
+ *
+ * @param String|Object selector    CSS3, XPath, name or label
+ * @param Mixed         value       Value being set
+ * @param String|Object form        (optional) CSS3 or XPath selector of form
+ * @param Object        options     Options to setFieldValue, it accepts:
+ *                                  - options.selectorType name|labes|xpath|css3 - type of selector, where
+ *                                    CSS3 and XPath(object) is autodetected (need not be set)
+ */
+Casper.prototype.setFieldValue = function setFieldValue(selector, value, form, options) {
+    "use strict";
+    this.checkStarted();
+
+    var selectorType = options && options.selectorType;
+
+    var result = this.evaluate(function _evaluate(selector, value, form, selectorType) {
+        if (selectorType) {
+            selector = __utils__.makeSelector(selector, selectorType);
+        }
+        return __utils__.setFieldValue(selector, value, {'formSelector': form});
+    }, selector, value, form, selectorType);
+
+    if (!result) {
+        throw new CasperError("Unable to set field '" + selector + " to value: " + value) +
+            ' in setFieldValue().';
+    }
+};
+
+/**
+ * Alias to setFieldValue() with implicit type name
+ *
+ * @param String        name    Name of form field
+ * @param Mixed         value   Value being set
+ * @param String|Object form    (optional) CSS3 or XPath selector of form
+ */
+Casper.prototype.setFieldValueName = function setFieldValueName(name, value, form) {
+    "use strict";
+    this.checkStarted();
+    this.setFieldValue(name, value, form, {'selectorType': 'name'});
+};
+
+/**
+ * Alias to setFieldValue() with implicit type label
+ *
+ * @param String        name    Name of form field
+ * @param Mixed         value   Value being set
+ * @param String|Object form    (optional) CSS3 or XPath selector of form
+ */
+Casper.prototype.setFieldValueLabel = function setFieldValueLabel(label, value, form) {
+    "use strict";
+    this.checkStarted();
+    this.setFieldValue(label, value, form, {'selectorType': 'label'});
+};
+
 /**
  * Sets current WebPage instance the credentials for HTTP authentication.
  *

--- a/modules/clientutils.js
+++ b/modules/clientutils.js
@@ -660,23 +660,23 @@
             type = type || 'xpath'; // default type
             var ret;
 
-            if (typeof selector === "object") { //selector object (CSS3 | XPath) could by passed
+            if (typeof selector === "object") { // selector object (CSS3 | XPath) could by passed
                 selector = selector.path;
             }
 
             switch (type) {
-                case 'css': //do nothing
+                case 'css': // do nothing
                     ret = selector;
                     break;
-                case 'name': //convert to css 
+                case 'name': // convert to css 
                 case 'names': 
                     ret = '[name="' + selector + '"]';
                     break;
-                case 'label': //covert to xpath object
+                case 'label': // covert to xpath object
                 case 'labels': 
                     ret = {type:'xpath', path:'//*[@id=string(//label[text()="' + selector + '"]/@for)]'};
                     break;
-                case 'xpath': //covert to xpath object
+                case 'xpath': // covert to xpath object
                     ret = {type:'xpath', path: selector};
                     break;
                 default:
@@ -684,7 +684,7 @@
             }
 
             return ret;
-        }
+        };
 
         /**
          * Dispatches a mouse event to the DOM element behind the provided selector.
@@ -871,7 +871,7 @@
                 return false;
             }
             return true;
-        }
+        };
 
         /**
          * Sets a field (or a set of fields) value. Fails silently, but log

--- a/modules/clientutils.js
+++ b/modules/clientutils.js
@@ -241,10 +241,12 @@
          *
          * @param  HTMLElement|String  form      A form element, or a CSS3 selector to a form element
          * @param  Object              vals      Field values
-         * @param  Function            findType  Element finder type (css, names, xpath)
+         * @param  String              findType  Element finder type (css, names, xpath, labels)
          * @return Object                        An object containing setting result for each field, including file uploads
          */
         this.fill = function fill(form, vals, findType) {
+            findType = findType || "names";
+
             /*eslint complexity:0*/
             var out = {
                 errors: [],
@@ -269,30 +271,13 @@
                 return out;
             }
 
-            var finders = {
-                css: function(inputSelector, formSelector) {
-                    return this.findAll(inputSelector, form);
-                },
-                labels: function(labelText, formSelector, value) {
-                    var label = this.findOne({type: "xpath", path: '//label[text()="' + labelText + '"]'}, form);
-                    if(label && label.htmlFor) {
-                        return this.findAll('#' + label.htmlFor, form);
-                    }
-                },
-                names: function(elementName, formSelector) {
-                    return this.findAll('[name="' + elementName + '"]', form);
-                },
-                xpath: function(xpath, formSelector) {
-                    return this.findAll({type: "xpath", path: xpath}, form);
-                }
-            };
-
             for (var fieldSelector in vals) {
                 if (!vals.hasOwnProperty(fieldSelector)) {
                     continue;
                 }
-                var field = finders[findType || "names"].call(this, fieldSelector, form),
-                    value = vals[fieldSelector];
+
+                var field = this.findAll(this.makeSelector(fieldSelector, findType), form);
+                var value = vals[fieldSelector];
                 if (!field || field.length === 0) {
                     out.errors.push('no field matching ' + findType + ' selector "' + fieldSelector + '" in form');
                     continue;
@@ -325,7 +310,7 @@
         /**
          * Finds all DOM elements matching by the provided selector.
          *
-         * @param  String            selector  CSS3 selector
+         * @param  String | Object   selector  CSS3 selector (String only) or XPath object
          * @param  HTMLElement|null  scope     Element to search child elements within
          * @return Array|undefined
          */
@@ -346,7 +331,7 @@
         /**
          * Finds a DOM element by the provided selector.
          *
-         * @param  String            selector  CSS3 selector
+         * @param  String | Object   selector  CSS3 selector (String only) or XPath object
          * @param  HTMLElement|null  scope     Element to search child elements within
          * @return HTMLElement|undefined
          */
@@ -659,6 +644,49 @@
         };
 
         /**
+         * Makes selector by defined type XPath, Name or Label. Function has same result as selectXPath in Casper module for 
+         * XPath type - it makes XPath object. 
+         * Function also accepts name attribut of the form filed or can select element by its label text.
+         *
+         * @param  String selector Selector of defined type
+         * @param  String|null  type Type of selector, it can have these values:     
+         *         css - CSS3 selector - selector is returned trasparently
+         *         xpath - XPath selector - return XPath object    
+         *         name|names - select input of specific name, internally covert to CSS3 selector
+         *         label|labels - select input of specific label, internally covert to XPath selector. As selector is label's text used.
+         * @return String|Object          
+         */
+        this.makeSelector = function makeSelector(selector, type){
+            type = type || 'xpath'; // default type
+            var ret;
+
+            if (typeof selector === "object") { //selector object (CSS3 | XPath) could by passed
+                selector = selector.path;
+            }
+
+            switch (type) {
+                case 'css': //do nothing
+                    ret = selector;
+                    break;
+                case 'name': //convert to css 
+                case 'names': 
+                    ret = '[name="' + selector + '"]';
+                    break;
+                case 'label': //covert to xpath object
+                case 'labels': 
+                    ret = {type:'xpath', path:'//*[@id=string(//label[text()="' + selector + '"]/@for)]'};
+                    break;
+                case 'xpath': //covert to xpath object
+                    ret = {type:'xpath', path: selector};
+                    break;
+                default:
+                    throw new Error("Unsupported selector type: " + type);
+            }
+
+            return ret;
+        }
+
+        /**
          * Dispatches a mouse event to the DOM element behind the provided selector.
          *
          * @param  String   type     Type of event to dispatch
@@ -799,6 +827,51 @@
             xhr.send(method === "POST" ? dataString : null);
             return xhr.responseText;
         };
+
+        /**
+         * Sets a value to form field by CSS3 or XPath selector. 
+         *
+         * With makeSelector() helper can by easily used with name or label selector 
+         *     @exemple setFieldValue(this.makeSelector('email', 'name'), 'value')
+         *  
+         * @param String|Object CSS3|XPath selector
+         * @param Mixed         Input value
+         * @param Object options Options for setFieldValue, accept formSelector: selector (optional)
+         * @return bool
+         */
+        this.setFieldValue = function setFieldValue(selector, value, options){
+            options = options || {};
+            var scope;
+            var formSelector = '';
+
+            if (options.formSelector) {
+                formSelector = options.formSelector;
+                if (!(scope = this.findOne(formSelector))) {
+                    this.log('setFieldValue() could not find form with selector: ' + selector, "error");
+                    return false;
+                } 
+            }
+            
+            var field = this.findAll(selector, scope);
+
+
+            if (!field || field.length === 0) {
+                this.log('setFieldValue(): unable to find field ' + selector, "error");
+                return false;
+            }
+            
+            try {
+                var ret = this.setField(field, value);
+            } catch (err) {
+                if (err.message) {
+                    this.log(err.message, "error");
+                }else{
+                    this.log('Error in setFieldValue() with selector: ' + selector, "error");
+                }
+                return false;
+            }
+            return true;
+        }
 
         /**
          * Sets a field (or a set of fields) value. Fails silently, but log

--- a/tests/suites/casper/formfill.js
+++ b/tests/suites/casper/formfill.js
@@ -1,5 +1,6 @@
 /*eslint strict:0*/
 var fs = require('fs');
+var x = require('casper').selectXPath;
 
 function testFormValues(test) {
     test.assertField('email', 'chuck@norris.com',
@@ -315,3 +316,108 @@ casper.test.begin('fillSelectors() tests', 4, function(test) {
         test.done();
     });
 });
+
+//
+// setFieldValue() tests
+//
+casper.test.begin('setFieldValue() tests with css3 selector and form', 9, function(test) {
+    casper.start('tests/site/form.html', function() {
+        var data = {
+            "input[name='email']":        'chuck@norris.com',
+            "input[name='password']":     42,
+            "textarea[name='content']":   'Am watching thou',
+            "input[name='check']":        true,
+            "input[name='choice']":       'no',
+            "select[name='topic']":       'bar',
+            "select[name='multitopic']":  ['bar', 'car'],
+            "input[name='checklist[]']":  ['1', '3'],
+            "input[name='strange']":      "very"
+        };
+
+        for (var selector in data){
+            this.setFieldValue(selector, data[selector], 'form[action="result.html"]');
+        }
+        testFormValues(test);
+    });
+
+    casper.run(function() {
+        test.done();    
+    });
+});
+
+casper.test.begin('setFieldValue() tests with XPath selector', 9, function(test) {
+    casper.start('tests/site/form.html', function() {
+        var data = {
+            '//input[@name="email"]':       'chuck@norris.com',
+            '//input[@name="password"]':    42,
+            '//textarea[@name="content"]':  'Am watching thou',
+            '//input[@name="check"]':       true,
+            '//input[@name="choice"]':      'no',
+            '//select[@name="topic"]':      'bar',
+            '//select[@name="multitopic"]': ['bar', 'car'],
+            '//input[@name="checklist[]"]': ['1', '3'],
+            '//input[@name="strange"]':     "very"
+        };
+
+        for (var selector in data){
+            this.setFieldValue(x(selector), data[selector]);
+        }
+        testFormValues(test);
+    });
+
+    casper.run(function() {
+        test.done();
+    });
+});
+
+casper.test.begin('setFieldValueName() tests', 9, function(test) {
+    casper.start('tests/site/form.html', function() {
+        var data = {
+            email:         'chuck@norris.com',
+            password:      42,
+            content:       'Am watching thou',
+            check:         true,
+            choice:        'no',
+            topic:         'bar',
+            multitopic:    ['bar', 'car'],
+            'checklist[]': ['1', '3'],
+            strange:       "very"
+        };
+
+        for (var selector in data){
+            this.setFieldValueName(selector, data[selector]);
+        }
+        testFormValues(test);
+    });
+
+    casper.run(function() {
+        test.done();
+    });
+});
+
+casper.test.begin('setFieldValueLabel() tests', 9, function(test) {
+    casper.start('tests/site/form.html', function() {
+        var data = {
+            Email:         'chuck@norris.com',
+            Password:      42,
+            Content:       'Am watching thou',
+            Check:         true,
+            No:            true,
+            Topic:         'bar',
+            Multitopic:    ['bar', 'car'],
+            "1":           true,
+            "3":           true,
+            Strange:       "very"     
+        };
+
+        for (var selector in data){
+            this.setFieldValueLabel(selector, data[selector]);
+        }
+        testFormValues(test);
+    });
+
+    casper.run(function() {
+        test.done();
+    });
+});
+// end setFieldValue() test

--- a/tests/suites/clientutils.js
+++ b/tests/suites/clientutils.js
@@ -249,3 +249,38 @@ casper.test.begin('ClientUtils.getElementInfo() visibility tests', 4, function(t
 
     test.done();
 });
+
+casper.test.begin('ClientUtils.makeSelector() tests', 8, function(test) {
+    var clientutils = require('clientutils').create();
+    
+    // CSS selector
+    var cssSelector = clientutils.makeSelector('#css3selector', 'css');
+    test.assertEquals(cssSelector, '#css3selector',
+        'ClientUtils.makeSelector() can process a CSS3 selector');
+
+    // XPath selector 
+    var xpathSelector = clientutils.makeSelector('//li[text()="blah"]', 'xpath');
+    test.assertType(xpathSelector, 'object',
+        'ClientUtils.makeSelector() can process a XPath selector');
+    test.assertEquals(xpathSelector.type, 'xpath',
+        'ClientUtils.makeSelector() can process a XPath selector');
+    test.assertEquals(xpathSelector.path, '//li[text()="blah"]',
+        'ClientUtils.makeSelector() can process a XPath selector');
+
+    // Name selector
+    var nameSelector = clientutils.makeSelector('parameter', 'names');
+    test.assertEquals(nameSelector, '[name="parameter"]',
+        'ClientUtils.makeSelector() can process a XPath selector');
+
+    // Label selector
+    var labelSelector = clientutils.makeSelector('Male', 'labels');
+    test.assertType(labelSelector, 'object',
+        'ClientUtils.makeSelector() can process a Label selector');
+    test.assertEquals(labelSelector.type, 'xpath',
+        'ClientUtils.makeSelector() can process a Label selector');
+    test.assertEquals(labelSelector.path, '//*[@id=string(//label[text()="Male"]/@for)]',
+        'ClientUtils.makeSelector() can process a Label selector');
+
+    test.done();
+});
+


### PR DESCRIPTION
…dValueLabel

Methods sets form field value by CSS3, XPath, name or label. Form reference is not needed.

SlimerJS ends me with errors - same as origin/master - so I ignered them.

Documentation is missing, please look first to my code.

Thanks