### PR TITLE
Fix support of page.resource.* on slimerjs 0.10

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -1213,7 +1213,8 @@ Casper.prototype.handleReceivedResource = function(resource) {
     }
     this.resources.push(resource);
 
-    var checkUrl = utils.ltVersion(phantom.version, '2.1.0') ? utils.decodeUrl(resource.url) : resource.url;
+    var checkUrl = utils.ltVersion(phantom.version, '2.1.0') &&
+                        (phantom.casperEngine !== 'slimerjs') ? utils.decodeUrl(resource.url) : resource.url;
     if (checkUrl !== this.requestUrl) {
         return;
     }
@@ -2644,7 +2645,8 @@ function createPage(casper) {
     };
     page.onResourceRequested = function onResourceRequested(requestData, request) {
         casper.emit('resource.requested', requestData, request);
-    	var checkUrl = utils.ltVersion(phantom.version, '2.1.0') ? utils.decodeUrl(requestData.url) : requestData.url;
+        var checkUrl = utils.ltVersion(phantom.version, '2.1.0') &&
+                        (phantom.casperEngine !== 'slimerjs') ? utils.decodeUrl(requestData.url) : requestData.url;
         if (checkUrl === casper.requestUrl) {
             casper.emit('page.resource.requested', requestData, request);
         }


### PR DESCRIPTION
Events page.resource.received and page.resource.requested were not emitted
on Slimerjs 0.10.
It fixes some tests.