### PR TITLE
Update casper.rst

### DIFF
--- a/docs/modules/casper.rst
+++ b/docs/modules/casper.rst
@@ -496,19 +496,8 @@ Example::
 
     casper.then(function() {
         // Click on 1st result link
-        this.click('h3.r a');
-    });
-
-    casper.then(function() {
-        // Click on 1st result link
-        this.click('h3.r a',10,10);
-    });
-
-    casper.then(function() {
-        // Click on 1st result link
         this.click('h3.r a',"50%","50%");
     });
-
 
     casper.then(function() {
         console.log('clicked ok, new location is ' + this.getCurrentUrl());


### PR DESCRIPTION
removed two click examples, so that the script will run without crashing once you add in `var casper = require('casper').create();`

Based on https://github.com/casperjs/casperjs/issues/1566 that I raised. This click example runs correctly and gives an example of the two extra parameters.
