### PR TITLE
Add fetchText - plain text example.

### DIFF
--- a/tests/suites/casper/fetchtext.js
+++ b/tests/suites/casper/fetchtext.js
@@ -38,3 +38,14 @@ casper.test.begin('fetchText() handles empty elements', 1, function(test) {
         test.done();
     });
 });
+
+casper.test.begin('fetchText() handles plain texts', 1, function(test) {
+    casper.start().then(function() {
+        this.setContent('This is a plain text.');
+        test.assertEquals(this.fetchText('html'), 'This is a plain text.',
+            'Casper.fetchText() handles plain texts');
+    });
+    casper.run(function() {
+        test.done();
+    });
+});


### PR DESCRIPTION
This shows how fetchText can be used as an alternative to getPlainText.
Maybe somehow useful for advanced peoples.
Regarding the analysis done here - https://github.com/casperjs/casperjs/issues/178#issuecomment-219226480