### PR TITLE
Creates getPlainText()

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -980,6 +980,17 @@ Casper.prototype.getPageContent = function getPageContent() {
 };
 
 /**
+ * Retrieves current page contents in plain text.
+ *
+ * @return String
+ */
+Casper.prototype.getPlainText = function getPlainText() {
+    "use strict";
+    this.checkStarted();
+    return this.page.framePlainText;
+};
+
+/**
  * Retrieves current document url.
  *
  * @return String

--- a/tests/suites/casper/getplaintext.js
+++ b/tests/suites/casper/getplaintext.js
@@ -1,0 +1,11 @@
+/*eslint strict:0*/
+casper.test.begin('getPlainText() handles plain texts', 1, function(test) {
+    casper.start().then(function() {
+        this.setContent('This is a plain text.');
+        test.assertEquals(this.getPlainText(), 'This is a plain text.',
+            'Casper.getPlainText() handles plain texts');
+    });
+    casper.run(function() {
+        test.done();
+    });
+});


### PR DESCRIPTION
Creates a very simple function to return plain data that is currently visible to the viewer.
https://github.com/casperjs/casperjs/issues/178#issuecomment-219220406

Should the naming of the function matter?