### PR TITLE
pass through the --ssl-client-certificate-file option to phantomjs

### DIFF
--- a/bin/casperjs
+++ b/bin/casperjs
@@ -34,6 +34,7 @@ SUPPORTED_ENGINES = {
             'script-encoding',
             'ssl-protocol',
             'ssl-certificates-path',
+            'ssl-client-certificate-file',
             'web-security',
             'webdriver',
             'webdriver-logfile',

--- a/src/casperjs.cs
+++ b/src/casperjs.cs
@@ -41,6 +41,7 @@ class phantomjs : engine {
             "script-encoding",
             "ssl-protocol",
             "ssl-certificates-path",
+            "ssl-client-certificate-file",
             "web-security",
             "webdriver",
             "webdriver-logfile",


### PR DESCRIPTION
Currently there is no way to pass the --ssl-client-certificate-file option to phantomjs. This fixes that.