### PR TITLE
sendAJAX custom headers

### DIFF
--- a/docs/modules/clientutils.rst
+++ b/docs/modules/clientutils.rst
@@ -416,7 +416,7 @@ Sends an AJAX request, using the following parameters:
 - ``method``: The HTTP method (default: ``GET``).
 - ``data``: Request parameters (default: ``null``).
 - ``async``: Flag for an asynchroneous request? (default: ``false``)
-- ``settings``: Other settings when perform the AJAX request (default: ``null``)
+- ``settings``: Custom Headers when perform the AJAX request (default: ``null``). WARNING: an invalid header here may make the request fail silently.
 
 .. warning::
 

--- a/modules/clientutils.js
+++ b/modules/clientutils.js
@@ -880,10 +880,12 @@
                 xhr.overrideMimeType(settings.overrideMimeType);
             }
             if (settings && settings.headers) {
-               for(var header in settings.headers) {
-                   if(header === CONTENT_TYPE_HEADER) { // this way Content-Type is correctly overriden,
-                                                        // otherwise it is strangely concatenated by
-                                                        // xhr.setRequestHeader()
+               for (var header in settings.headers) {
+                   if (header === CONTENT_TYPE_HEADER) {
+                      // this way Content-Type is correctly overriden,
+                      // otherwise it is concatenated by xhr.setRequestHeader()
+                      // see https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/setRequestHeader
+                      // If the header was already set, the value will be augmented.
                        contentTypeValue = settings.headers[header];
                    } else {
                        xhr.setRequestHeader(header, settings.headers[header]);

--- a/modules/clientutils.js
+++ b/modules/clientutils.js
@@ -862,7 +862,8 @@
          * @param   String   method   HTTP method (default: GET).
          * @param   Object   data     Request parameters.
          * @param   Boolean  async    Asynchroneous request? (default: false)
-         * @param   Object   settings Other settings when perform the ajax request like some undocumented Request Headers.
+         * @param   Object   settings Other settings when perform the ajax request like some undocumented
+         * Request Headers.
          * WARNING: an invalid header here may make the request fail silently.
          * @return  String            Response text.
          */
@@ -880,7 +881,9 @@
             }
             if (settings && settings.headers) {
                for(var header in settings.headers) {
-                   if(header === CONTENT_TYPE_HEADER) {//this way Content-Type is correctly overriden, otherwise it is strangely concatenated by xhr.setRequestHeader()
+                   if(header === CONTENT_TYPE_HEADER) { // this way Content-Type is correctly overriden,
+                                                        // otherwise it is strangely concatenated by
+                                                        // xhr.setRequestHeader()
                        contentTypeValue = settings.headers[header];
                    } else {
                        xhr.setRequestHeader(header, settings.headers[header]);

--- a/modules/clientutils.js
+++ b/modules/clientutils.js
@@ -862,19 +862,30 @@
          * @param   String   method   HTTP method (default: GET).
          * @param   Object   data     Request parameters.
          * @param   Boolean  async    Asynchroneous request? (default: false)
-         * @param   Object   settings Other settings when perform the ajax request
+         * @param   Object   settings Other settings when perform the ajax request like some undocumented Request Headers.
+         * WARNING: an invalid header here may make the request fail silently.
          * @return  String            Response text.
          */
         this.sendAJAX = function sendAJAX(url, method, data, async, settings) {
             var xhr = new XMLHttpRequest(),
                 dataString = "",
                 dataList = [];
+            var CONTENT_TYPE_HEADER = "Content-Type";
             method = method && method.toUpperCase() || "GET";
-            var contentType = settings && settings.contentType || "application/x-www-form-urlencoded";
+            var contentTypeValue = settings && settings.contentType || "application/x-www-form-urlencoded";
             xhr.open(method, url, !!async);
             this.log("sendAJAX(): Using HTTP method: '" + method + "'", "debug");
             if (settings && settings.overrideMimeType) {
                 xhr.overrideMimeType(settings.overrideMimeType);
+            }
+            if (settings && settings.headers) {
+               for(var header in settings.headers) {
+                   if(header === CONTENT_TYPE_HEADER) {//this way Content-Type is correctly overriden, otherwise it is strangely concatenated by xhr.setRequestHeader()
+                       contentTypeValue = settings.headers[header];
+                   } else {
+                       xhr.setRequestHeader(header, settings.headers[header]);
+                   }
+              }
             }
             if (method === "POST") {
                 if (typeof data === "object") {
@@ -889,7 +900,7 @@
                 } else if (typeof data === "string") {
                     dataString = data;
                 }
-                xhr.setRequestHeader("Content-Type", contentType);
+                xhr.setRequestHeader(CONTENT_TYPE_HEADER, contentTypeValue);
             }
             xhr.send(method === "POST" ? dataString : null);
             return xhr.responseText;

--- a/sendAjax.js
+++ b/sendAjax.js
@@ -1,0 +1,60 @@
+/*eslint strict:0*/
+/**
+ * Special test server to test sendAJAX function
+ *
+ */
+var utils = require('utils');
+
+casper.test.begin("__utils__.sendAJAX() POST Custom Headers tests", 7, {
+    setUp: function(test) {
+        this.server = require('webserver').create();
+        this.requestReceived = null;
+        this.server.listen(8585, function (request, response) {
+            requestReceived = request;
+            response.statusCode = 200;
+            response.write("");
+            response.close();
+        });
+    },
+
+    tearDown: function() {
+        this.server.close();
+        this.requestReceived = null;
+    },
+
+    test: function(test) {
+        var wsurl = 'http://127.0.0.1:8585';
+        casper.userAgent("Googlebot/2.1 (+http://www.google.com/bot.html)");
+        casper.start().then(function() {
+            this.evaluate(function(wsurl) {
+                var customData = {"requestData":"dummydata"};
+                var customSettings = {
+                    headers:{
+                        "Accept": "*/*",
+                        "Accept-Language": "pt-BR,en,*",
+                        "Content-Type": "multipart/form-data",
+                        "Host" : "192.168.0.2:8584",
+                        "Origin": "http://google.com"
+                        //For some reason underlying XMLHttpRequest.setRequestHeader() doesn't let you
+                        //set this and others Headers as well.
+                        //,"User-Agent": "Googlebot/2.1 (+http://www.google.com/bot.html)"
+                    }
+                };
+                return __utils__.sendAJAX(wsurl, 'POST', customData, false, customSettings);
+            }, {wsurl: wsurl})
+        }).then(function(){
+            test.assertEquals(requestReceived.method, "POST", "AJAX POST Request has been received!");
+            test.assertEquals(requestReceived.post, "requestData=dummydata", "Data from AJAX POST Request has been received!");
+            test.assertEquals(requestReceived.headers["Accept"], "*/*","Accept header is set! We're going to accept anything!");
+            test.assertEquals(requestReceived.headers["Accept-Language"], "pt-BR,en,*","Accept-Language is set! Server is now talking Portuguese!");
+            test.assertEquals(requestReceived.headers["Content-Type"], "multipart/form-data","Content-Type is set! Server is now expecting to receive a form!");
+            test.assertEquals(requestReceived.headers["Host"], "192.168.0.2:8584","Host is set! Arbitary IP was given to the server!");
+            test.assertEquals(requestReceived.headers["Origin"], "http://google.com","Origin is set! Server thinks we came from google!");
+            //test.assertEquals(requestReceived.headers["User-Agent"], "Googlebot/2.1 (+http://www.google.com/bot.html)","User-Agent is set! Server thinks we're a googlebot!");
+        });
+
+        casper.run(function() {
+            this.test.done();
+        });
+    }
+});

--- a/sendAjax.js
+++ b/sendAjax.js
@@ -35,8 +35,11 @@ casper.test.begin("__utils__.sendAJAX() POST Custom Headers tests", 7, {
                         "Content-Type": "multipart/form-data",
                         "Host" : "192.168.0.2:8584",
                         "Origin": "http://google.com"
-                        //For some reason underlying XMLHttpRequest.setRequestHeader() doesn't let you
-                        //set this and others Headers as well.
+                        /* For security reasons, you may not set any header you like here.
+                        See: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/setRequestHeader
+                             https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name
+                             https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_response_header_name
+                        */
                         //,"User-Agent": "Googlebot/2.1 (+http://www.google.com/bot.html)"
                     }
                 };


### PR DESCRIPTION
fix #1560 

Hi guys! Please, take a look @Sayalic0 @paazmaya @istr I'm also no expert in JavaScript and I'm using this exercise to learn a bit :)

I've started from #1562 and tried to improve it. But I still feel this PR is dirty for a number of reasons:
1. I couldn't make the integration tests run on the **`tests/modules`** folder (**sendAjax.js** file). Have no idea why;
2. **Integration test takes ~30s to run!** This is a lifetime! I don't have the tiniest idea why the request/response takes so long. I will send you an even dirtier experiment where I bring up one **caperjs webserver** in on console and make the **sendAJAX()** request on another console. It runs instantly;
3. I was only able to run the integration test with the following command line:

``` shell
$ casperjs test sendAjax.js --web-security=no
```

So I don't know how to integrate it with the selftest suite even though @istr has already given me testing directions on #1603.
