### PR TITLE
can't open program #1180

### DIFF
--- a/bin/casperjs
+++ b/bin/casperjs
@@ -130,11 +130,13 @@ for arg in SYS_ARGS:
 CASPER_COMMAND = [ENGINE_EXECUTABLE]
 CASPER_COMMAND.extend(ENGINE_ARGS)
 CASPER_COMMAND.extend([
-    os.path.join(CASPER_PATH, 'bin', 'bootstrap.js'),
-    '--casper-path=%s' % CASPER_PATH,
+    '\"'+os.path.join(CASPER_PATH, 'bin', 'bootstrap.js')+'\"',
+    '--casper-path=\"%s\"' % CASPER_PATH,
     '--cli'
 ])
 CASPER_COMMAND.extend(CASPER_ARGS)
+
+print CASPER_COMMAND
 
 try:
     # print(CASPER_COMMAND)

--- a/bin/casperjs
+++ b/bin/casperjs
@@ -136,7 +136,6 @@ CASPER_COMMAND.extend([
 ])
 CASPER_COMMAND.extend(CASPER_ARGS)
 
-print CASPER_COMMAND
 
 try:
     # print(CASPER_COMMAND)


### PR DESCRIPTION
This issue is because node can't current parse the command width absolute path have space.Like this

     node  D:\\Program Files\\nodejs\\node_modules\\casperjs\\bin\\casperjs\\bootstrap.js

execute this command will take an error "can't open D:\\program".Node parse this as "node  D:\\Program".

So we can add en enclosing double quotation marks to this command .

    node  "D:\\Program Files\\nodejs\\node_modules\\casperjs\\bin\\casperjs\\bootstrap.js"

It will execute correctly.This issue maybe not only exist in win.Since win default install casperjs to "C:\Program Files",the win's user the more likely  to encounter the problem.

With my modify ,execute "capserjs selftest", will 3 failed.There are two  of them is the test merge string is not rigorous.Another one ,I don't find the reason.

It seems that this problem has been dealt with before #1319.