### PR TITLE
fix for evaluate function. in case if user passes one array argument …

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -715,7 +715,7 @@ Casper.prototype.evaluate = function evaluate(fn, context) {
     } else if (arguments.length === 2) {
         // check for closure signature if it matches context
         if (utils.isObject(context) && eval(fn).length === Object.keys(context).length) {
-            /** 
+            /*
              * in case if user passes argument as one array with only one object.
              * evaluate shlould return original array with one object
              * instead of converte this array to object

--- a/modules/casper.js
+++ b/modules/casper.js
@@ -714,8 +714,17 @@ Casper.prototype.evaluate = function evaluate(fn, context) {
         return utils.clone(this.page.evaluate(fn));
     } else if (arguments.length === 2) {
         // check for closure signature if it matches context
-        if (!utils.isArray(context) && utils.isObject(context) && eval(fn).length === Object.keys(context).length) {
-            context = utils.objectValues(context);
+        if (utils.isObject(context) && eval(fn).length === Object.keys(context).length) {
+            /** 
+             * in case if user passes argument as one array with only one object.
+             * evaluate shlould return original array with one object
+             * instead of converte this array to object
+             */
+            if (utils.isArray(context) && context.length === 1) {
+                context = [context];
+            } else {
+                context = utils.objectValues(context);
+            }
         } else {
             context = [context];
         }

--- a/modules/casper.js
+++ b/modules/casper.js
@@ -714,7 +714,7 @@ Casper.prototype.evaluate = function evaluate(fn, context) {
         return utils.clone(this.page.evaluate(fn));
     } else if (arguments.length === 2) {
         // check for closure signature if it matches context
-        if (utils.isObject(context) && eval(fn).length === Object.keys(context).length) {
+        if (!utils.isArray(context) && utils.isObject(context) && eval(fn).length === Object.keys(context).length) {
             context = utils.objectValues(context);
         } else {
             context = [context];

--- a/tests/suites/casper/evaluate.js
+++ b/tests/suites/casper/evaluate.js
@@ -52,11 +52,11 @@ casper.test.begin('handling of array context', 3, function(test) {
     test.assertEquals(casper.evaluate(function(a) {
         return a;
     }, ["foo"]), ["foo"], 'Casper.evaluate() accepts an array as arguments context');
-    test.assertEquals(casper.evaluate(function(a, b) {
-        return [a, b];
+    test.assertEquals(casper.evaluate(function(a) {
+        return a;
     }, ["foo", "bar"]), ["foo", "bar"], 'Casper.evaluate() accepts an array as arguments context');
-    test.assertEquals(casper.evaluate(function(a, b, c) {
-        return [a, b, c];
+    test.assertEquals(casper.evaluate(function(a) {
+        return a;
     }, ["foo", "bar", "baz"]), ["foo", "bar", "baz"], 'Casper.evaluate() accepts an array as arguments context');
     test.done();
 });

--- a/tests/suites/casper/evaluate.js
+++ b/tests/suites/casper/evaluate.js
@@ -50,7 +50,7 @@ casper.test.begin('handling of object context (BC mode)', 3, function(test) {
 casper.test.begin('handling of array context', 3, function(test) {
     casper.start();
     test.assertEquals(casper.evaluate(function(a) {
-        return [a];
+        return a;
     }, ["foo"]), ["foo"], 'Casper.evaluate() accepts an array as arguments context');
     test.assertEquals(casper.evaluate(function(a, b) {
         return [a, b];

--- a/tests/suites/casper/evaluate.js
+++ b/tests/suites/casper/evaluate.js
@@ -52,11 +52,11 @@ casper.test.begin('handling of array context', 3, function(test) {
     test.assertEquals(casper.evaluate(function(a) {
         return a;
     }, ["foo"]), ["foo"], 'Casper.evaluate() accepts an array as arguments context');
-    test.assertEquals(casper.evaluate(function(a) {
-        return a;
+    test.assertEquals(casper.evaluate(function(a, b) {
+        return [a, b];
     }, ["foo", "bar"]), ["foo", "bar"], 'Casper.evaluate() accepts an array as arguments context');
-    test.assertEquals(casper.evaluate(function(a) {
-        return a;
+    test.assertEquals(casper.evaluate(function(a, b, c) {
+        return [a, b, c];
     }, ["foo", "bar", "baz"]), ["foo", "bar", "baz"], 'Casper.evaluate() accepts an array as arguments context');
     test.done();
 });


### PR DESCRIPTION
hey guys. here is a fix for evaluate function. in case if user passes one array argument with one object. evaluate converted this array to object instead return original array with one object.

example 

```
let mockArray = [];

//any actions
mockArray.push({
  name: 'casper'
});
casper.evaluate(function (arr) {
       //I expect that arr = [{name: 'casper'}]
       //but it returns {name:'casper'}
       //so my fix is for this case, to return [{name: 'casper'}] instead of {name:'casper'}
 }, mockArray);
```
