### PR TITLE
Exclude vector logo from npm package

### DIFF
--- a/docs/_static/images/.npmignore
+++ b/docs/_static/images/.npmignore
@@ -1,0 +1,4 @@
+.npmignore
+*.ai
+*.pdf
+*.eps


### PR DESCRIPTION
refs #1632 - Exclude ai, pdf and eps logo files from npm package