### PR TITLE
Downloaded.error emit

### DIFF
--- a/docs/events-filters.rst
+++ b/docs/events-filters.rst
@@ -156,6 +156,13 @@ Emitted when the ``Casper.die()`` method has been called.
 
 Emitted when a file has been downloaded by :ref:`Casper.download() <casper_download>`; ``target`` will contain the path to the downloaded file.
 
+``downloaded.error``
+~~~~~~~~~~~~~~~~~~~
+
+**Arguments:** ``url``
+
+Emitted when a file has encoutered an error when downloaded by :ref:`Casper.download() <casper_download>`; ``url`` will contain the url of the downloaded file.
+
 .. index:: error
 
 ``error``

--- a/modules/casper.js
+++ b/modules/casper.js
@@ -608,6 +608,7 @@ Casper.prototype.download = function download(url, targetPath, method, data) {
         this.emit('downloaded.file', targetPath);
         this.log(f("Downloaded and saved resource in %s", targetPath));
     } catch (e) {
+        this.emit('downloaded.error', url);
         this.log(f("Error while downloading %s to %s: %s", url, targetPath, e), "error");
     }
     return this;


### PR DESCRIPTION
In writing a program that will download files, I found it very useful to listen for the downloaded.file event, but had no way to test for the download failing. I added a new custom event for an error so that i can listen to it.

I also added an entry for the docs so that other users can use it.
