### PR TITLE
add runScript method : equivalent to Webpage#evaluateAsync

### DIFF
--- a/docs/modules/casper.rst
+++ b/docs/modules/casper.rst
@@ -1593,6 +1593,42 @@ Casper suite **will run**::
 
 Binding a callback to ``complete.error`` will trigger when the ``onComplete`` callback fails.
 
+``runScript()``
+-------------------------------------------------------------------------------
+
+**Signature:** ``runScript(Function fn[, arg1[, arg2[, …]]], callback)``
+
+Basically `PhantomJS' WebPage#evaluateAsync <http://phantomjs.org/api/webpage/method/evaluateAsync.html>`_ equivalent. Asynchronous evaluates an expression **in the current page DOM context**::
+
+    casper.runScript(function(text) {
+        return document.title;
+    }, 'new title : ',
+    function(ret) {
+        this.echo(ret);
+    });
+
+    casper.runScript(function(text) {
+        callCasper(document.title);
+    }, function(ret) {
+        this.echo(ret);
+    });
+
+
+    casper.runScript(function(text) {
+        document.addEventListener('click',function(){
+            callCasper(document.title);
+        });
+    }, 
+    function(ret) {
+        this.echo(ret);
+    });
+.. note::
+
+   For forcing return use the "callCasper" method
+
+.. topic:: Understanding ``evaluate()``
+
+
 .. index:: Scroll
 
 ``scrollTo()``

--- a/modules/casper.js
+++ b/modules/casper.js
@@ -143,6 +143,7 @@ var Casper = function Casper(options) {
     this.mouse = mouse.create(this);
     this.popups = pagestack.create();
     // properties
+    this.callbacks = {};
     this.checker = null;
     this.currentResponse = {};
     this.currentUrl = 'about:blank';
@@ -1567,6 +1568,95 @@ Casper.prototype.run = function run(onComplete, time) {
     return this;
 };
 
+
+/**
+ * Evaluates an expression in the page context, without blocking the current execution
+ * a bit like what WebPage#evaluateAsync does, but the passed function can also accept
+ * parameters if a context Object is also passed:
+ *
+ *     casper.runScript(function(username, password) {
+ *         setTimeout(function(){
+ *             document.querySelector('#username').value = username;
+ *             document.querySelector('#password').value = password;
+ *             document.querySelector('#submit').click();
+ *         }, 1000);
+ *         return "launch";
+ *     }, 'Bazoonga', 'baz00nga', function(ret){
+ *         this.echo(ret);
+ *     });
+ *
+ * @param  Function  fn       The function to be evaluated within current page DOM
+ * @param  Object    context  Object containing the parameters to inject into the function (optional)
+ * @param  Function  callback A callback function to call when script ended
+ * @return mixed
+ * @see    WebPage#evaluateAsync
+ */
+Casper.prototype.runScript = function runScript(fn, context, callback) {
+    "use strict";
+    this.checkStarted();
+    // check whether javascript is enabled !!
+    if (this.options.pageSettings.javascriptEnabled === false) {
+        throw new CasperError("evaluate() requires javascript to be enabled");
+    }
+    // preliminary checks
+    if (!utils.isFunction(fn) && !utils.isString(fn)) { // phantomjs allows functions defs as string
+        throw new CasperError("evaluate() only accepts functions or strings");
+    }
+    // ensure client utils are always injected
+    this.injectClientUtils();
+    // function context
+    var args = [].slice.call(arguments);
+    var code = new Date().getTime();
+    while (this.callbacks[code]){
+        code = new Date().getTime();
+    }
+    if (args.length > 0 && utils.isFunction(args[args.length-1])) {
+        callback = args[args.length-1];
+    }
+    if (args.length === 1) {
+        context = [];
+    } else if (args.length === 2) {
+        // check for closure signature if it matches context
+        if (utils.isObject(context) && eval(fn).length === Object.keys(context).length) {
+            context = utils.objectValues(context);
+        } else {
+            context = [context];
+        }
+    } else {
+        // phantomjs-style signature
+        context = [].slice.call(args, 1);
+    }
+    var closure = ["function(){var args=[].slice.apply(arguments);var code=args.pop();"+
+    "function callCasper(data){window.callPhantom({'type':'casperJs-runScript','id':code,'ret':data});}",
+    "}"];
+ 
+    if (fn.toString().indexOf("callCasper") === -1) {
+        fn = closure.join("callCasper((" + fn.toString() + ").apply(null,args));");
+    } else {
+        fn = closure.join("(" + fn.toString() + ").apply(null,args);");
+    }
+    
+    if (!(phantom.casperEngine === 'slimerjs' && utils.ltVersion(slimer.version, '0.10.0'))) {
+        // reverse parameter because of phantom bug
+        context = (phantom.casperEngine === 'slimerjs')? context.concat([code]) : context.concat([code]).reverse();
+
+        this.page.evaluateAsync.apply(this.page, [fn].concat([1]).concat(context));
+        
+    } else {
+
+        fn = "function() { setTimeout(" + fn + ", 1" ;
+        for (var i=0,l=context.length+1;i<l;i++){
+            fn += ", arguments[" + (i+1) + "]";
+        }
+        fn += "); }";
+        this.page.evaluate.apply(this.page, [fn].concat([1]).concat(context).concat([code]));
+    }
+    this.callbacks[code] = callback;
+    return this.waitFor(function isEvaluateReceived() {
+        return Object.keys(this.callbacks).length === 0 ;
+    });
+};
+
 /**
  * Runs a step.
  *
@@ -2641,6 +2731,13 @@ function createPage(casper) {
     };
 
     page.onCallback = function onCallback(data){
+        if (data && data.type === "casperJs-runScript") {
+            if (data.id && casper.callbacks[data.id]) {
+                casper.callbacks[data.id](data.ret);
+                delete casper.callbacks[data.id];
+                return;
+            }
+        }
         casper.emit('remote.callback',data);
     };
 

--- a/samples/runScript.js
+++ b/samples/runScript.js
@@ -1,0 +1,65 @@
+/*eslint strict:0*/
+/*global CasperError, console*/
+
+/**
+ * Asynchronous evaluate script
+ */
+
+
+var casper = require("casper").create();
+
+
+casper.start('http://casperjs.org').then(function() {
+    this.echo("CasperJS connected.");
+});
+
+casper.then(function(){
+    console.log('Synchronous mode, title: "' + this.evaluate(function() {
+        return document.title;
+    }) + '"');
+});
+
+casper.then(function(){
+    this.runScript(function() {
+        return document.title;
+    }, function callback(ret){
+       console.log('Asynchronous defaut return, title: "' + ret + '"');
+    });
+
+    this.runScript(function() {
+        return document.title;
+    }, function callback(ret) {
+        console.log('Asynchronous same mode, title: "' + ret + '"');
+    });
+
+    this.runScript(function() {
+        callCasper(document.title);
+        return true;
+    }, function callback(ret) {
+       console.log('Asynchronous force callback, title: "' + ret + '"');
+    });
+
+    this.runScript(function() {
+        setTimeout(function() {
+	    callCasper(document.title);
+        }, 1000);
+    }, function callback(ret) {
+       console.log('Asynchronous with setTimeout (1s), title: "' + ret + '"');
+    });
+
+    this.runScript(function() {
+        document.addEventListener('click',function(e) {
+            callCasper(document.title);
+        },false);
+        setTimeout(function(){
+            __utils__.click('body');
+        },1000);
+    }, function callback(ret) {
+       console.log('Asynchronous on Event Listener, title: "' + ret + '"');
+    });
+});
+
+casper.run(function() {
+    this.echo('terminated');
+    this.exit();
+});

--- a/tests/suites/casper/evaluate.js
+++ b/tests/suites/casper/evaluate.js
@@ -128,3 +128,43 @@ casper.test.begin("evaluate() with js disabled, throws error", 1, function(test)
         casper.options.pageSettings.javascriptEnabled = true;
     });
 });
+
+casper.test.begin('runScript() tests', 4, function(test) {
+    casper.options.waitTimeout = 20000;
+    casper.start().then(function() {
+        casper.runScript(function() {
+            return "foo";
+        },  function(ret) {
+           test.assertEquals(ret, "foo", "Casper.runScript() no arg");
+        });
+    });
+    casper.then(function() {
+        casper.runScript(function(a, b) {
+            return a + b;
+        }, "foo", "bar", function(ret) {
+           test.assertEquals(ret, "foobar", "Casper.runScript() sets args");
+        });
+    });
+    casper.then(function() {
+        casper.runScript(function(a, b) {
+            callCasper(a + b );
+            return a + a;
+        }, "foo", "bar", function(ret) {
+           test.assertEquals(ret, "foobar", "Casper.runScript() sets args diff return value");
+        });
+    });
+    casper.then(function() {
+        casper.runScript(function(a, b) {
+	    setTimeout(function(){
+                callCasper(a + b );
+            },300);
+            return a + a;
+        }, "foo", "bar", function(ret) {
+           test.assertEquals(ret, "foobar", "Casper.runScript() sets args and setTimeout");
+        });
+    });
+    casper.run(function() {
+        test.done();
+        casper.options.waitTimeout = 5000;
+    });
+});


### PR DESCRIPTION
Hi,

CasperJS has never coded the PhantomJS method "evaluateAsync". But as @mickaelandrieu said on #1373 : 

> it could be better for now to create new functions instead of improve the existing one

because of JavaScript programming is now moving towards a purely asynchronous programming.

So this PR allows to run asynchronous evaluate with a "casper.runScript" method.
I don't named it "evaluateAsync" because (it's ugly) it is not the same prototype as the PhantomJS method.

casper.runScript accepts a callback function with one argument : the return data or the "callCasper" data.

samples : 

``` js
casper.runScript(function(text) {
    return text + document.title;
}, 'new title: ', function(ret) {
    this.echo(ret);
});


casper.runScript(function(text) {
    document.addEventListener('click',function(){
        callCasper(document.title);
    });
   return "ignored";
}, function(title) {
    this.echo(title);
});
```

return : 

> new title: CasperJS, a navigation scripting and testing utility for PhantomJS and SlimerJS
> CasperJS, a navigation scripting and testing utility for PhantomJS and SlimerJS

Regards
jef
