### PR TITLE
suggestion for PhantomJS API reference in documentation

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -368,7 +368,7 @@ After casperjs.start(), you have phantomjs page module available in casper.page 
 
 You can simply do like below::
 
-  casper.page.pageModuleApi()
+  casper.page.nameOfMethod()
 
 PhantomJS Web Page API: http://phantomjs.org/api/webpage/
 


### PR DESCRIPTION
I was confused by the notation in the documentation here on the PhantomJS API that is available through casperjs.

Before it said `casper.page.casperPageApi()`, which made me think that I had to call that method to get access to the API methods. in reality, those methods are available at `casper.page`.

My change makes it a bit clearer for me (I think `.nameOfMethod` suggests that we're calling a method of some-other-name), but I can also see this being written as an example that calls an existing method in PhantomJS's page API. Any thoughts?
