### PR TITLE
refs #1677. Use the svg namespace resolver to find the svg node using xpath

### DIFF
--- a/modules/clientutils.js
+++ b/modules/clientutils.js
@@ -55,6 +55,10 @@
             41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, -1, -1, -1, -1, -1
         ];
         var SUPPORTED_SELECTOR_TYPES = ['css', 'xpath'];
+        var XPATH_NAMESPACE = {
+            svg: 'http://www.w3.org/2000/svg',
+            mathml: 'http://www.w3.org/1998/Math/MathML'
+        };
 
         // public members
         this.options = options || {};
@@ -543,7 +547,7 @@
          */
         this.getElementByXPath = function getElementByXPath(expression, scope) {
             scope = scope || this.options.scope;
-            var a = document.evaluate(expression, scope, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
+            var a = document.evaluate(expression, scope, this.xpathNamespaceResolver, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
             if (a.snapshotLength > 0) {
                 return a.snapshotItem(0);
             }
@@ -559,11 +563,21 @@
         this.getElementsByXPath = function getElementsByXPath(expression, scope) {
             scope = scope || this.options.scope;
             var nodes = [];
-            var a = document.evaluate(expression, scope, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
+            var a = document.evaluate(expression, scope, this.xpathNamespaceResolver, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
             for (var i = 0; i < a.snapshotLength; i++) {
                 nodes.push(a.snapshotItem(i));
             }
             return nodes;
+        };
+
+        /**
+         * Build the xpath namespace resolver to evaluate on document
+         *
+         * @param String        prefix   The namespace prefix
+         * @return the resolve namespace or null
+         */
+        this.xpathNamespaceResolver = function xpathNamespaceResolver(prefix) {
+          return XPATH_NAMESPACE[prefix] || null;
         };
 
         /**

--- a/tests/suites/clientutils.js
+++ b/tests/suites/clientutils.js
@@ -47,6 +47,39 @@ casper.test.begin('ClientUtils.exists() tests', 5, function(test) {
     test.done();
 });
 
+casper.test.begin('ClientUtils.exists() with svg tests', 3, function(test) {
+  var clientutils = require('clientutils').create();
+  fakeDocument('<div class="foo"><svg><text>SVG</text></svg></div>');
+  test.assert(clientutils.exists('div.foo svg'),
+      'ClientUtils.exists() checks that an svg element exist');
+  test.assert(clientutils.exists(selectXPath('//div/svg:svg')),
+      'ClientUtils.exists() checks that an svg element exist using XPath');
+  test.assert(clientutils.exists(selectXPath('//div/svg:svg/svg:text')),
+      'ClientUtils.exists() checks that an svg element exist using XPath');
+  fakeDocument(null);
+  test.done();
+});
+
+casper.test.begin('ClientUtils.exists() with mathml tests', 3, function(test) {
+  var clientutils = require('clientutils').create();
+  var html = "<div class='foo'>We will now prove the Pythogorian theorem:";
+      html +=   "<math> <mrow>"
+      html +=     "<msup><mi> a </mi><mn>2</mn></msup> <mo> + </mo>";
+      html +=     "<msup><mi> b </mi><mn>2</mn></msup>";
+      html +=     "<mo> = </mo> <msup><mi> c </mi><mn>2</mn></msup>";
+      html +=   "</mrow> </math>";
+      html += "</div>";
+  fakeDocument(html);
+  test.assert(clientutils.exists('div.foo math'),
+      'ClientUtils.exists() checks that an math element exist');
+  test.assert(clientutils.exists(selectXPath('//div/mathml:math')),
+      'ClientUtils.exists() checks that an math element exist using XPath');
+  test.assert(clientutils.exists(selectXPath('//div/mathml:math/mathml:mrow/mathml:msup[1]')),
+      'ClientUtils.exists() checks that an math element exist using XPath');
+  fakeDocument(null);
+  test.done();
+});
+
 casper.test.begin('ClientUtils.findAll() tests', 7, function(test) {
     var clientutils = require('clientutils').create();
     fakeDocument('<ul class="foo"><li>bar</li><li>baz</li></ul>');


### PR DESCRIPTION
We use Document.evaluate to returns an XPathResult based on an XPath expression and other given parameters.

```js
var xpathResult = document.evaluate(
 xpathExpression, 
 contextNode, 
 namespaceResolver, 
 resultType, 
 result
);
```
**namespaceResolver** is a function that will be passed any namespace prefixes and should return a string representing the namespace URI associated with that prefix. It will be used to resolve prefixes within the XPath itself, so that they can be matched with the document. null is common for HTML documents or when no namespace prefixes are used.

So for svg nodes, we should use namespace ```http://www.w3.org/2000/svg```.