### PR TITLE
Local config async

### DIFF
--- a/docs/modules/tester.rst
+++ b/docs/modules/tester.rst
@@ -679,6 +679,28 @@ A more asynchronous example::
         }
     });
 
+This could even be asynchronous functions:
+
+    var asyncCow;
+    casper.test.begin('Async Cows can fly', 2, {
+        setUp: function(test, globalCasper, callback) {
+            setTimeout(function() {
+                asyncCow = new AsyncCow();
+                callback();
+            }, 10);
+        },
+        tearDown: function(test, globalCasper, callback) {
+            setTimeout(function() {
+                asyncCow.destroy();
+                callback();
+            }, 10);
+        },
+        test: function(test) {
+            test.assertEquals(asyncCow.fly(), 'swoosh!');
+            test.done();
+        }
+    });
+
 .. index:: Colors
 
 ``colorize()``
@@ -917,7 +939,7 @@ Defines a function which will be executed before every test defined using `begin
 
 To perform asynchronous operations, use the ``done`` argument::
 
-    casper.test.setUp(function(done) {
+    casper.test.setUp(function(test, globalCasper, done) {
         casper.start('http://foo').then(function() {
             // ...
         }).run(done);
@@ -956,7 +978,7 @@ Defines a function which will be executed after every test defined using `begin(
 
 To perform asynchronous operations, use the ``done`` argument::
 
-    casper.test.tearDown(function(done) {
+    casper.test.tearDown(function(test, globalCasper, done) {
         casper.start('http://foo/goodbye').then(function() {
             // ...
         }).run(done);

--- a/modules/tester.js
+++ b/modules/tester.js
@@ -1100,8 +1100,8 @@ Tester.prototype.begin = function begin() {
 
     function getConfig(args) {
         var config = {
-            setUp: function(){},
-            tearDown: function(){}
+            setUp: null,
+            tearDown: null
         };
 
         if (utils.isFunction(args[1])) {
@@ -1143,22 +1143,25 @@ Tester.prototype.begin = function begin() {
     this.executed = 0;
     this.running = this.started = true;
 
+    var _setUpFn = config.setUp || this._setUp;
+    var _context = utils.isFunction(config.setUp) ? config : this;
+
+    if (!utils.isFunction(_setUpFn)) {
+        return next();
+    }
+
     try {
-        if (config.setUp)
-            config.setUp(this, this.casper);
-
-        if (!this._setUp)
-            return next();
-
-        if (this._setUp.length > 0)
-            return this._setUp.call(this, next); // async
-
-        this._setUp.call(this);                  // sync
-        next();
+        if (_setUpFn.length > 2) {
+            _setUpFn.call(_context, this, this.casper, next); // async
+        } else {
+            _setUpFn.call(_context, this, this.casper); // sync
+            next();
+        }
     } catch (err) {
         this.processError(err);
         this.done();
     }
+
 };
 
 /**
@@ -1198,14 +1201,6 @@ Tester.prototype.done = function done() {
         planned = arguments[0];
     }
 
-    if (config && config.tearDown && utils.isFunction(config.tearDown)) {
-        try {
-            config.tearDown(this, this.casper);
-        } catch (error) {
-            this.processError(error);
-        }
-    }
-
     var next = function() {
         if (this.currentSuite && this.currentSuite.planned &&
             this.currentSuite.planned !== this.executed + this.currentSuite.skipped &&
@@ -1217,7 +1212,7 @@ Tester.prototype.done = function done() {
         }
         if (this.currentSuite) {
             this.suiteResults.push(this.currentSuite);
-            
+
             if (!this.options.concise) {
                 this.casper.echo([
                     this.colorize('PASS', 'INFO'),
@@ -1227,7 +1222,7 @@ Tester.prototype.done = function done() {
                             config.planned > 1 ? 's' : ''), 'INFO')
                 ].join(' '));
             }
-            
+
             this.currentSuite = undefined;
             this.executed = 0;
         }
@@ -1240,17 +1235,20 @@ Tester.prototype.done = function done() {
         }
     }.bind(this);
 
-    if (!this._tearDown) {
+    var _tearDownFn = config.tearDown || this._tearDown;
+    var _context = utils.isFunction(config.tearDown) ? config : this;
+
+    if (!utils.isFunction(_tearDownFn)) {
         return next();
     }
 
     try {
-        if (this._tearDown.length > 0) {
+        if (_tearDownFn.length > 2) {
             // async
-            this._tearDown.call(this, next);
+            _tearDownFn.call(_context, this, this.casper, next);
         } else {
             // sync
-            this._tearDown.call(this);
+            _tearDownFn.call(_context, this, this.casper);
             next();
         }
     } catch (error) {
@@ -1602,7 +1600,6 @@ Tester.prototype.renderResults = function renderResults(exit, status, save) {
 
 /**
  * Runs all suites contained in the paths passed as arguments.
- *
  */
 Tester.prototype.runSuites = function runSuites() {
     "use strict";

--- a/tests/suites/tester/setup-teardown-async-inline.js
+++ b/tests/suites/tester/setup-teardown-async-inline.js
@@ -1,0 +1,36 @@
+/*eslint strict:0*/
+
+var setUp, tearDown;
+
+casper.test.begin('setUp() tests', 1, {
+  setUp: function(test, globalCasper, callback) {
+      setTimeout(function() {
+          setUp = true;
+          callback();
+      }, 50);
+  },
+  test: function(test) {
+    test.assertTrue(setUp, 'Tester.setUp() executed the async setup function');
+    test.done();
+  }
+});
+
+casper.test.begin('tearDown() dummy test', 1, {
+  tearDown: function(test, globalCasper, callback) {
+      setTimeout(function() {
+          tearDown = true;
+          callback();
+      }, 50);
+  },
+  test: function(test) {
+    test.assertTrue(true); // This is just a dummy test. See the next one.
+    test.done();
+  }
+});
+
+casper.test.begin('tearDown() test', 1, function(test) {
+  // This test only ensures that the tearDown function
+  // of the previous test was called.
+  test.assertTrue(tearDown, 'Tester.tearDown() executed the async tear down function');
+  test.done();
+})

--- a/tests/suites/tester/setup-teardown-async.js
+++ b/tests/suites/tester/setup-teardown-async.js
@@ -2,17 +2,17 @@
 
 var setUp, tearDown;
 
-casper.test.setUp(function(done) {
+casper.test.setUp(function(test, globalCasper, callback) {
     setTimeout(function() {
         setUp = true;
-        done();
+        callback();
     }, 50);
 });
 
-casper.test.tearDown(function(done) {
+casper.test.tearDown(function(test, globalCasper, callback) {
     setTimeout(function() {
         tearDown = true;
-        done();
+        callback();
         // reset
         casper.test.setUp();
         casper.test.tearDown();
@@ -25,6 +25,7 @@ casper.test.begin('setUp() tests', 1, function(test) {
 });
 
 casper.test.begin('tearDown() tests', 1, function(test) {
+    // This test works only, because the setUp-Test was called first..
     test.assertTrue(tearDown, 'Tester.tearDown() executed the async tear down function');
     test.done();
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | yes
| API-Change | yes
| Tests pass?   | yes
| Fixed tickets | #1715 

This PR cleans adds the general ability for all setUp/tearDown functions to be asynchronous.
I introduced a BC break here, because all setUp/tearDown function get the `tester` and `casper` instance passed, and as third argument the callback. This is done to clean up the code and to clarify the usage.
I know I could have avoided that BC break by checking if the first param is a function, and if so, assume that this is a callback, but the code is way more expressive now.