### PR TITLE
Quote CLI paths to engine in bin/casperjs

### DIFF
--- a/bin/casperjs
+++ b/bin/casperjs
@@ -142,8 +142,8 @@ for arg in SYS_ARGS:
 CASPER_COMMAND = [ENGINE_EXECUTABLE]
 CASPER_COMMAND.extend(ENGINE_ARGS)
 CASPER_COMMAND.extend([
-    os.path.join(CASPER_PATH, 'bin', 'bootstrap.js'),
-    '--casper-path=%s' % CASPER_PATH,
+    '"%s"' % os.path.join(CASPER_PATH, 'bin', 'bootstrap.js'),
+    '--casper-path="%s"' % CASPER_PATH,
     '--cli'
 ])
 CASPER_COMMAND.extend(CASPER_ARGS)


### PR DESCRIPTION
Refs #1180.

My fix for #1180 by quoting paths sent to engine (phantomjs in my case).