### PR TITLE
page.clearMemoryCache(): clearMemoryCache() + clearCache() + loadImages defineProperty

### DIFF
--- a/docs/modules/casper.rst
+++ b/docs/modules/casper.rst
@@ -667,6 +667,54 @@ Think of it as a way to stop javascript execution within the remote DOM environm
 
     casper.run();
 
+.. _casper_clearcache:
+
+.. index:: Memory
+
+``clearCache()``
+-------------------------------------------------------------------------------
+
+**Signature:** ``clearCache()``
+
+.. versionadded:: 1.1.5
+
+Replace current page by a new page object, with newPage() and clear the memory cache, with clearMemoryCache().
+Example::
+
+    casper.start('http://www.google.fr/', function() {
+        this.clearCache(); // cleared the memory cache and replaced page object with newPage().
+    });
+
+    casper.then(function() {
+        // ...
+    });
+
+    casper.run();
+
+.. _casper_clearmemorycache:
+
+.. index:: Memory
+
+``clearMemoryCache()``
+-------------------------------------------------------------------------------
+
+**Signature:** ``clearMemoryCache()``
+
+.. versionadded:: 1.1.5
+
+Use the engine page.clearMemoryCache() to clear the memory cache.
+Example::
+
+    casper.start('http://www.google.fr/', function() {
+        this.clearMemoryCache(); // cleared the memory cache.
+    });
+
+    casper.then(function() {
+        // ...
+    });
+
+    casper.run();
+
 .. index:: Debugging
 
 ``debugHTML()``

--- a/modules/casper.js
+++ b/modules/casper.js
@@ -465,6 +465,39 @@ Casper.prototype.clear = function clear() {
 };
 
 /**
+ * Replace currente page by a new page object, with newPage()
+ * Clears the memory cache, with clearMemoryCache()
+ * 
+ * @return Casper
+ */
+Casper.prototype.clearCache = function clearCache() {
+    "use strict";
+    this.checkStarted();
+    this.page = this.newPage();
+    this.clearMemoryCache();
+    return this;
+};
+
+/**
+ * Clears the memory cache, using engine method
+ * reference: https://github.com/ariya/phantomjs/issues/10357
+ *
+ * @return Casper
+ */
+Casper.prototype.clearMemoryCache = function clearMemoryCache() {
+    "use strict";
+    this.checkStarted();
+    if (typeof this.page.clearMemoryCache === 'function') {
+        this.page.clearMemoryCache();
+    } else if ( phantom.casperEngine === 'slimerjs' || utils.matchEngine({name: 'phantomjs', version: {min: '2.0.0'}}) ) {
+        this.log('clearMemoryCache() did nothing: page.clearMemoryCache is not avliable in this engine', "warning");
+    } else {
+        throw new CasperError("clearMemoryCache(): page.clearMemoryCache should be avaliable in this engine");
+    };
+    return this;
+};
+
+/**
  * Emulates a click on the element from the provided selector using the mouse
  * pointer, if possible.
  *

--- a/modules/casper.js
+++ b/modules/casper.js
@@ -3011,6 +3011,19 @@ function createPage(casper) {
             "y": 0
         };
 
+        page.settings.loadImagesValue = page.settings.loadImages;
+        Object.defineProperty(page.settings,'loadImages', {
+            get: function() { 
+                return page.settings.loadImagesValue;
+            },
+            set: function(newValue) {
+                page.settings.loadImagesValue = newValue;
+                if (typeof page.clearMemoryCache === 'function') {
+                    page.clearMemoryCache();
+                };
+            }
+        });
+
         page.onClosing =  function() {
             var p = page;
             return function() {


### PR DESCRIPTION
I think it might be useful, as Changelog says newPage() was created as "option to create a new WebPage instance to address memory consumption issues (#803, #826)".