### PR TITLE
Add waitForExec method.

### DIFF
--- a/docs/modules/casper.rst
+++ b/docs/modules/casper.rst
@@ -2215,6 +2215,58 @@ Waits until a `JavaScript alert <https://developer.mozilla.org/en-US/docs/Web/AP
         this.echo("Alert received: " + response.data);
     });
 
+.. _casper_waitforexec:
+
+.. index:: Child Process, Spawn, exec File
+
+``waitForExec()``
+-------------------------------------------------------------------------------
+**Signature:** ``waitForExec(command, parameters[, Function then, Function onTimeout, timeout])``
+
+.. versionadded:: 1.1.5
+
+Waits until ``command`` runs with ``parameters`` and exits. The ``command``, ``parameters``, ``pid``, ``stdout``, ``stderr``, ``elapsedTime`` and ``exitCode`` will be in the ``response.data`` property.
+``command`` must be a string or ``parameters`` must be an array.
+``command`` can be an string of a executable or an string of a executable and its arguments separated by spaces. If ``command`` is falsy or is not a string, system shell (environment variable SHELL or ComSpec) is used. The arguments separated by spaces are concatenated with the ``parameters`` array to be send to executable. If ``parameters`` is falsy or is not an array, an empty array is used.
+``timeout`` can be a number or an array of two numbers, the first is the timeout of ``wait*`` family functions and the second is the timeout between TERM and KILL signals on timeout. If not declared, it assumes the same value of the first element or the default timeout of ``wait*`` family functions.::
+
+    // merge captured PDFs with default system shell (bash on Linux) calling /usr/bin/gs, and runs a small script to remove files
+    casper.waitForExec(null, ['-c','{ /usr/bin/gs -dPDFSETTINGS=/ebook -dBATCH -dNOPAUSE -q -sDEVICE=pdfwrite -sOutputFile=/my_merged_captures.pdf  /my_captures*.pdf && /bin/rm /my_captures*.pdf; } || { /bin/rm /my_merged_captures.pdf && exit 1; }'],
+        function(response) {
+            this.echo("Program finished by itself:" + JSON.stringify(response.data));
+        }, function(timeout, response) {
+            this.echo("Program finished by casper:" + JSON.stringify(response.data));
+    });
+    
+     // merge captured PDFs with bash calling /usr/bin/gs, and runs a small script to remove files
+    casper.waitForExec('/bin/bash -c', ['{ /usr/bin/gs -dPDFSETTINGS=/ebook -dBATCH -dNOPAUSE -q -sDEVICE=pdfwrite -sOutputFile=/my_merged_captures.pdf  /my_captures*.pdf && /bin/rm /my_captures*.pdf; } || { /bin/rm /my_merged_captures.pdf && exit 1; }'],
+        function(response) {
+            this.echo("Program finished by itself:" + JSON.stringify(response.data));
+        }, function(timeout, response) {
+            this.echo("Program finished by casper:" + JSON.stringify(response.data));
+    });
+
+
+    // merge captured PDFs calling /usr/bin/gs
+    casper.waitForExec('/usr/bin/gs',['-dPDFSETTINGS=/ebook','-dBATCH','-dNOPAUSE','-q','-sDEVICE=pdfwrite','-sOutputFile=/my_merged_captures_pdfs.pdf','/my_captures_1.pdf','/my_captures_2.pdf','/my_captures_3.pdf'],
+        function(response) {
+            this.echo("Program finished by itself:" + JSON.stringify(response.data));
+        }, function(timeout, response) {
+            this.echo("Program finished by casper:" + JSON.stringify(response.data));
+    });
+
+    // merge captured PDFs calling /usr/bin/gs
+    casper.waitForExec('/usr/bin/gs -dPDFSETTINGS=/ebook -dBATCH -dNOPAUSE -q -sDEVICE=pdfwrite -sOutputFile=/my_merged_captures_pdfs.pdf /my_captures_1.pdf /my_captures_2.pdf /my_captures_3.pdf', null,
+        function(response) {
+            this.echo("Program finished by itself:" + JSON.stringify(response.data));
+        }, function(timeout, response) {
+            this.echo("Program finished by casper:" + JSON.stringify(response.data));
+    });
+
+.. warning::
+
+   waitForExec() **only kills the called program on timeout**. If the called program calls other processes, they won't be killed when waitForExec() times out.
+
 .. _casper_waitforpopup:
 
 .. index:: Popups, New window, window.open, Tabs

--- a/tests/suites/casper/wait.js
+++ b/tests/suites/casper/wait.js
@@ -167,3 +167,149 @@ casper.test.begin('waitForUrl() string tests', 1, function(test) {
         test.done();
     });
 });
+
+casper.test.begin('waitForExec() tests', 24, function(test) {
+    if (phantom.casperEngine === 'slimerjs') {
+        test.skip(24, 'SlimerJS DOES NOT HAVE A child_process MODULE');  
+    } else {    
+        var system = require('system');
+        var fs = require('fs');
+        var lsExecutable;
+        var shExecutable;
+        if (system.os.name != "windows") {
+            // Seems to be crashing here in slimerJs 0.10.x, added fs.exists before fs.isExecutable for testing
+            lsExecutable = system.env.PATH.split(':').filter(function (path) {
+                var fileString = path + fs.separator + 'ls';
+                return (fs.exists(fileString) && fs.isExecutable(fileString));
+            })[0] + fs.separator + 'ls';
+            shExecutable = system.env.PATH.split(':').filter(function (path) {
+                var fileString = path + fs.separator + 'sh';
+                return (fs.exists(fileString) && fs.isExecutable(fileString));
+            })[0] + fs.separator + 'sh';
+        };
+        var notExecutable = '';
+        var k = 0;
+        while (!notExecutable) {
+            notExecutable = (!fs.exists(fs.workingDirectory + fs.separator + 'run' + k + '.exe')) ? fs.workingDirectory + fs.separator + 'run' + k + '.exe' : '';
+            k++;
+        };
+        
+        casper.start('');
+
+        casper.waitForExec(null, [],
+            // Add success1 because on some systems the default system shell maybe exits by itself after being called(?)
+            null,
+            /*
+            function success1(details) {
+                test.assert((utils.isObject(details.data.command) && utils.isString(details.data.command.program) && utils.isArray(details.data.command.parameters)), 'Casper.waitForExec() can call the default system shell and it exits before timeout: "' + JSON.stringify(details.data.command) + '"');
+                test.assertEquals(details.data.isChildNotFinished, 0,'Default system shell returned "isChildNotFinished" 0 before timeout');
+                test.assert(utils.isNumber(details.data.exitCode), 'Default system shell "' + JSON.stringify(details.data.command) + '" exited before timeout with exit code ' + details.data.exitCode);
+                
+            },
+            */
+            function timeout1(timeout, details) {
+                // exit code value seems to be 0 when phantom kills the process before 2.1.1(?)
+                var valueOfExitCode = (utils.matchEngine({name: 'phantomjs', version: {min: '1.9.0', max: '2.1.0'}})) ? 0 : 15;
+                test.assert((utils.isString(details.data.command) && utils.isArray(details.data.parameters)), 'Casper.waitForExec() can call the default system shell and kills it on timeout: ' + JSON.stringify(details.data));
+                test.assert( (utils.isNumber(details.data.pid) && ( details.data.pid > 0) ), 'Default system shell exited on timeout (TERM signal) and used PID ' + details.data.pid);
+                test.assertEquals(details.data.isChildNotFinished, 0,'Default system shell returned "isChildNotFinished" 0 on timeout');
+                test.assertEquals(details.data.exitCode, valueOfExitCode, 'Default system shell exited on timeout (TERM signal) with exit code ' + details.data.exitCode);
+              
+        }, 2000);
+
+        casper.reload().waitForExec(notExecutable, [],
+            function success2(details) {
+                test.assert((utils.isString(details.data.command) && utils.isArray(details.data.parameters)), 'Casper.waitForExec() tried to call non existing executable: ' + JSON.stringify(details.data));
+                test.assertEquals(details.data.pid, 0,'Non existing executable returned "pid" 0');
+                test.assertEquals(details.data.isChildNotFinished, 0,'Non existing executable returned "isChildNotFinished" 0');
+                test.assertEquals(details.data.exitCode, null, 'Non existing executable returned exitCode null');
+                test.assertEquals(details.data.elapsedTime, null, 'Non existing executable returned elapsedTime null');
+        });
+
+        if (system.os.name != "windows") {
+            if (lsExecutable) {
+
+                casper.reload().waitForExec(lsExecutable, ['-a',fs.workingDirectory],
+                    function success3(details) {
+                        test.assert((utils.isString(details.data.command) && utils.isArray(details.data.parameters)), 'Casper.waitForExec() can call "lsExecutable" on "workingDirectory": ' + JSON.stringify(details.data));
+                        test.assert( (utils.isNumber(details.data.pid) && ( details.data.pid > 0) ), '"lsExecutable" on "workingDirectory" used PID ' + details.data.pid);
+                        test.assertEquals(details.data.isChildNotFinished, 0,'"lsExecutable" on "workingDirectory" returned "isChildNotFinished" 0');
+                        test.assertEquals(details.data.exitCode, 0, '"lsExecutable" on "workingDirectory" returned exitCode 0');
+                        test.assertTruthy(details.data.stdout, '"lsExecutable" on "workingDirectory" returned stdout ' + JSON.stringify(details.data.stdout));
+                });
+
+                casper.reload().waitForExec(lsExecutable, [notExecutable],
+                    function success4(details) {
+                        test.assert((utils.isString(details.data.command) && utils.isArray(details.data.parameters)), 'Casper.waitForExec() can call "lsExecutable" on "notExecutable": ' + JSON.stringify(details.data));
+                        test.assert( (utils.isNumber(details.data.pid) && ( details.data.pid > 0) ), '"lsExecutable" on "notExecutable" used PID ' + details.data.pid);
+                        test.assertEquals(details.data.isChildNotFinished, 0,'"lsExecutable" on "notExecutable" returned "isChildNotFinished" 0');
+                        test.assertTruthy(details.data.exitCode, '"lsExecutable" on "notExecutable" returned exitCode ' + details.data.exitCode);
+                        test.assertTruthy(details.data.stderr, '"lsExecutable" on "notExecutable" returned stderr ' + JSON.stringify(details.data.stderr));
+                });
+
+            } else {
+                casper.reload().then( function() {
+                    test.skip(10, 'ls EXECUTABLE NOT FOUND');  
+                });
+            };
+
+            if (shExecutable) {
+                // vars used to measure if 'shell script to trap TERM signal' is waiting enough and being killed faster enough
+                var shellTrapTimeout = 500;
+                var shellTrapTermTimeout = 1000;
+                var timeLapseAfterKillSignal = 300;
+                var minTimeLapse = shellTrapTimeout + shellTrapTermTimeout;
+                var maxTimeLapse = minTimeLapse + timeLapseAfterKillSignal;
+                casper.then( function() { // inside then for elapsedTime don't be added with other tests elapsedTime
+                    // on my tests 'TERM trapped!' will not be on stdout because 'shExecutable' is killed with SIGKILL
+                    casper.reload().waitForExec(shExecutable + ' -c', ['trap "echo TERM trapped!" TERM ; sleep 60'], null,
+                        function timeout5(timeout,details) {
+                            // exit code value seems to be 0 when phantom kills the process before 2.1.1(?)
+                            var valueOfExitCode = (utils.matchEngine({name: 'phantomjs', version: {min: '1.9.0', max: '2.1.0'}})) ? 0 : 9;
+                            test.assert((utils.isString(details.data.command) && utils.isArray(details.data.parameters)), 'Casper.waitForExec() can call shell script to trap TERM signal and then kills it: ' + JSON.stringify(details.data));
+                            test.assert( (utils.isNumber(details.data.pid) && ( details.data.pid > 0) ), 'shell script to trap TERM signal used PID ' + details.data.pid);
+                            test.assertEquals(details.data.isChildNotFinished, 0, 'shell script to trap TERM signal returned "isChildNotFinished" 0');
+                            test.assertEquals(details.data.exitCode, valueOfExitCode, 'shell script to trap TERM signal returned exitCode ' + details.data.exitCode);
+                            // test if it first waited for shellTrapTimeout ms, then waited for shellTrapTermTimeout ms after TERM signal, then exited faster (timeLapseAfterKillSignal ms or less) with KILL signal
+                            test.assert( (utils.isNumber(details.data.elapsedTime) && (details.data.elapsedTime <= maxTimeLapse) && (details.data.elapsedTime > minTimeLapse) ), 'shell script to trap TERM signal run and killed in more than ' + minTimeLapse + 'ms and in less than or equal to ' + maxTimeLapse + 'ms: ' + details.data.elapsedTime);
+                    }, [shellTrapTimeout, shellTrapTermTimeout]);
+                });
+                
+            } else {
+                casper.reload().then( function() {
+                    test.skip(5, 'sh EXECUTABLE NOT FOUND');  
+                });
+            };
+            
+        } else {
+            
+            casper.reload().waitForExec(null, ['/c', 'dir', fs.workingDirectory],
+                function(details) {
+                        test.assert((utils.isString(details.data.command) && utils.isArray(details.data.parameters)), 'Casper.waitForExec() can call dir on "workingDirectory": ' + JSON.stringify(details.data));
+                        test.assert( (utils.isNumber(details.data.pid) && ( details.data.pid > 0) ), 'dir on "workingDirectory" used PID ' + details.data.pid);
+                        test.assertEquals(details.data.isChildNotFinished, 0,'dir on "workingDirectory" returned "isChildNotFinished" 0');
+                        test.assertEquals(details.data.exitCode, 0, 'dir on "workingDirectory" returned exitCode 0');
+                        test.assertTruthy(details.data.stdout, 'dir on "workingDirectory" returned stdout ' + JSON.stringify(details.data.stdout));
+            });
+
+            casper.reload().waitForExec(null, ['/c', 'dir', notExecutable],
+                function(details) {
+                    test.assert((utils.isString(details.data.command) && utils.isArray(details.data.parameters)), 'Casper.waitForExec() can dir on "notExecutable": ' + JSON.stringify(details.data));
+                    test.assert( (utils.isNumber(details.data.pid) && ( details.data.pid > 0) ), 'dir on "notExecutable" used PID ' + details.data.pid);
+                    test.assertEquals(details.data.isChildNotFinished, 0, 'dir on "notExecutable" returned "isChildNotFinished" 0');
+                    test.assertTruthy(details.data.exitCode, 'dir on "notExecutable" returned exitCode ' + details.data.exitCode);
+                    test.assertTruthy(details.data.stderr, 'dir on "notExecutable" returned stderr ' + JSON.stringify(details.data.stderr));
+            });
+            
+            casper.reload().then( function() {
+                test.skip(5, 'WINDOWS SYSTEM, CAN NOT EASILY TRAP TERM SIGNAL ON SHELL SCRIPT');  
+            });
+            
+        };
+
+    };
+
+    casper.run(function() {
+        test.done();
+    });
+});


### PR DESCRIPTION
Add waitExec method.
Sometimes I need to call an external program and wait for it ends: for example, merge captured pdfs with an external program and upload the new file.

Then I developed this waitExec method, of course It needs some improvements, but what do you think about it? Is a good idea to add it to CasperJS? Or it isn't in the scope of the project?

The Child Process Module is described in http://phantomjs.org/api/child_process/, and an issue is that I have not found documentation for child.pid in PhantomJS. It seem to change to 0 when the process ends or when it can not be started. In PhantomJS 1.9.x, the exit code seems to be 0 when the process is killed by phantom (child.kill), and in 2.1.1 it's the process exit code.

I decided to use require("child_process").spawn despite require("child_process").execFile because I believe it should have the same behavior described in https://www.ericluwj.com/2015/11/25/nodejs-spawn-vs-execfile.html.
