### PR TITLE
Fix binary Request  self Test

### DIFF
--- a/tests/selftest.js
+++ b/tests/selftest.js
@@ -52,6 +52,7 @@ service = server.listen(testServerPort, function(request, response) {
         response.writeHead(200, headers);
 
         if (binMode) {
+            response.setEncoding("binary");
             response.write(fs.read(pageFile, 'b'));
         }
         else {


### PR DESCRIPTION
FIX Bug return binary data : Image image/png ; application/octet-stream

Pictures were never displayed because of this single bug  'response.setEncoding("binary");'