### PR TITLE
pageSettings DOCs update

### DIFF
--- a/docs/modules/casper.rst
+++ b/docs/modules/casper.rst
@@ -271,6 +271,8 @@ An existing PhantomJS ``WebPage`` instance
 PhantomJS's WebPage settings object. Available settings are:
 
 - ``javascriptEnabled`` defines whether to execute the script in the page or not (default to ``true``)
+- ``javascriptCanCloseWindows`` defines if javascript can close windows or not (default to ``true``)
+- ``javascriptCanOpenWindows`` defines if javascript can open windows or not (default to ``true``)
 - ``loadImages`` defines whether to load the inlined images or not
 - ``localToRemoteUrlAccessEnabled`` defines whether local resource (e.g. from file) can access remote URLs or not (default to ``false``)
 - ``userAgent`` defines the user agent sent to server when the web page requests resources


### PR DESCRIPTION
Should  `pageSettings` properties `javascriptCanOpenWindows` and `javascriptCanCloseWindows` be in the docs? `phantom.defaultPageSettings` has both set to true, but I haven't found any documentation about it, in CasperJS docs or in PhantomJS docs.

(SlimerJS has it documented in https://docs.slimerjs.org/current/configuration.html)