### PR TITLE
update cli.rst to properly format sample code block

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -148,7 +148,7 @@ If you run this script:
 
 As you can see, the ``01234567`` value has been cast to a *Number*.
 
-If you want the original string, use the ``raw`` property of the ``cli`` object, which contains the raw values of the passed parameters. For very long numbers, use the ``raw`` property as there is an ECMA script limitation with a numeric precision of up to 17 places. More info here - https://github.com/casperjs/casperjs/issues/1134
+If you want the original string, use the ``raw`` property of the ``cli`` object, which contains the raw values of the passed parameters::
 
     var casper = require('casper').create();
     var utils = require('utils');
@@ -166,3 +166,4 @@ Sample usage:
     1234567
     "01234567"
 
+For very long numbers, use the ``raw`` property as there is an ECMA script limitation with a numeric precision of up to 17 places. More info here - https://github.com/casperjs/casperjs/issues/1134


### PR DESCRIPTION
I've made a PR which somehow doesn't respect the Sphinx documentation syntax. Making an update so that the sample code block shows up as code block instead of plain text. I'm sorry for the oversight! It is my first time updating Sphinx documentation and I was not able to preview the actual change live. https://github.com/casperjs/casperjs/pull/1871/files